### PR TITLE
Add default RBAC for the Prometheus container

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -255,6 +255,52 @@ class PrometheusCharm(CharmBase):
 
         return yaml.dump(scrape_config)
 
+    def _prometheus_rbac(self):
+        """Construct Prometheus container RBAC
+        Based on https://github.com/prometheus-community/helm-charts/blob/97997ccc4bdd8699e74535dab24a861983a83b1e/charts/prometheus/templates/server/clusterrole.yaml
+        """
+
+        rbac_config = {
+            'roles': [{
+                'global': True,
+                'rules': [
+                    {
+                        'apiGroups': [''],
+                        'resources': [
+                            'nodes',
+                            'nodes/proxy',
+                            'nodes/metrics',
+                            'services',
+                            'endpoints',
+                            'pods',
+                            'ingresses',
+                            'configmaps'
+                        ],
+                        'verbs': ['get', 'list', 'watch'],
+                    },
+                    {
+                        'apiGroups': [
+                            'extensions',
+                            'networking.k8s.io',
+                        ],
+                        'resources': [
+                            'ingresses',
+                            'ingresses/status',
+                        ],
+                        'verbs': ['get', 'list', 'watch'],
+                    },
+                    {
+                        'nonResourceURLs': ['/metrics'],
+                        'verbs': ['get'],
+                    },
+                ]
+            }]
+        }
+
+        logger.debug('Prometheus RBAC config: {}'.format(rbac_config))
+
+        return rbac_config
+
     def _build_pod_spec(self):
         """Construct a Juju pod specification for Prometheus
         """
@@ -302,43 +348,7 @@ class PrometheusCharm(CharmBase):
                     }]
                 }]
             }],
-            'serviceAccount': {
-                'roles': [{
-                    'global': True,
-                    # From: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/templates/server/clusterrole.yaml
-                    'rules': [
-                        {
-                            'apiGroups': [''],
-                            'resources': [
-                                'nodes',
-                                'nodes/proxy',
-                                'nodes/metrics',
-                                'services',
-                                'endpoints',
-                                'pods',
-                                'ingresses',
-                                'configmaps'
-                            ],
-                            'verbs': ['get', 'list', 'watch'],
-                        },
-                        {
-                            'apiGroups': [
-                                'extensions',
-                                'networking.k8s.io',
-                            ],
-                            'resources': [
-                                'ingresses',
-                                'ingresses/status',
-                            ],
-                            'verbs': ['get', 'list', 'watch'],
-                        },
-                        {
-                            'nonResourceURLs': ['/metrics'],
-                            'verbs': ['get'],
-                        },
-                    ]
-                }]
-            }
+            'serviceAccount': self._prometheus_rbac(),
         }
 
         return spec

--- a/src/charm.py
+++ b/src/charm.py
@@ -301,7 +301,44 @@ class PrometheusCharm(CharmBase):
                         'content': self._prometheus_config()
                     }]
                 }]
-            }]
+            }],
+            'serviceAccount': {
+                'roles': [{
+                    'global': True,
+                    # From: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/templates/server/clusterrole.yaml
+                    'rules': [
+                        {
+                            'apiGroups': [''],
+                            'resources': [
+                                'nodes',
+                                'nodes/proxy',
+                                'nodes/metrics',
+                                'services',
+                                'endpoints',
+                                'pods',
+                                'ingresses',
+                                'configmaps'
+                            ],
+                            'verbs': ['get', 'list', 'watch'],
+                        },
+                        {
+                            'apiGroups': [
+                                'extensions',
+                                'networking.k8s.io',
+                            ],
+                            'resources': [
+                                'ingresses',
+                                'ingresses/status',
+                            ],
+                            'verbs': ['get', 'list', 'watch'],
+                        },
+                        {
+                            'nonResourceURLs': ['/metrics'],
+                            'verbs': ['get'],
+                        },
+                    ]
+                }]
+            }
         }
 
         return spec


### PR DESCRIPTION
This PR adds a default RBAC to the Prometheus Pod, enabling it to scrape the Kubernetes API to configure the [Kubernetes Service Discovery](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config).

I made a very simple PR to enable a default configuration, we can work on another PR to make it customizable via the `config.yaml`. What do you think?

Relates to #19.

