### PR TITLE
Revert scrape config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,22 +12,25 @@ cluster. The alerting component of prometheus is offered through a
 separate Charm.
 
 
-## Configuration and Usage
+## Usage
 
-By default the Prometheus Operator monitors itself. There are two ways
-to provide additional scrape targets to this Prometheus charm.
+By default the Prometheus Operator monitors itself, but it also
+accepts additional scrape targets over Juju relations with charms that
+support the `prometheus` interface and preferably use the Prometheus
+charm library. This charm library provides an `add_endpoint()` method
+that creates additional scrape targets. Each scrape target is expected
+to expose a `/metrics` HTTP path that exposes its metrics in a
+Prometheus compatible format.
 
-1. Using Juju the command line configuration option `scrape-config`.
-2. Using Juju relations with charms that support the `prometheus`
-   interface and preferably use the Prometheus charm library. This
-   charm library provides a `add_endpoint()` method to provide
-   additional scrape targets to Prometheus over relation data.
+At present it is expected that all relations the Prometheus Operator
+partakes in are within the same Juju model. Further development may
+extend this to allow cross model scrape targets.
 
 ## Dashboard
 
-The Prometheus dashboard may be accessed at port 9090 on the IP
-address of the Prometheus leader unit. This unit and its IP address
-may be determined using the `juju status` command.
+The Prometheus dashboard may be accessed at a selectable port (by
+default 9090) on the IP address of the Prometheus unit. This unit and
+its IP address may be determined using the `juju status` command.
 
 ## Relations
 
@@ -43,5 +46,5 @@ This charm by default uses the latest version of the Prometheus
 
 ## Contributing
 
-Please see the Juju [SDK docs](https://juju.is/docs/sdk) for guidlines
+Please see the Juju [SDK docs](https://juju.is/docs/sdk) for guidelines
 on developing enhancements to this charm following best practice guidelines.

--- a/config.yaml
+++ b/config.yaml
@@ -83,10 +83,6 @@ options:
       How long until a scrape request times out.
     type: string
     default: 10s
-  scrape-config:
-    description: |
-      Prometheus scrape configuration in YAML format
-    type: string
   evaluation-interval:
     description: |
       How frequently rules will be evaluated.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -40,4 +40,3 @@ resources:
   prometheus-image:
     type: oci-image
     description: upstream docker image for prometheus
-    upstream-source: "prom/prometheus:latest"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/balbirthomas/operator/@provider-consumer-lib#egg=ops
 semantic_version
 pyaml
+urllib3

--- a/src/charm.py
+++ b/src/charm.py
@@ -361,12 +361,6 @@ class PrometheusCharm(CharmBase):
         if alerting_config:
             scrape_config['alerting'] = alerting_config
 
-        scrape_config_string = config.get('scrape-config')
-        if scrape_config_string:
-            scrape_config_yaml = yaml.safe_load(scrape_config_string)
-            for scrape_job in scrape_config_yaml['scrape_configs']:
-                scrape_config['scrape_configs'].append(scrape_job)
-
         # By default only monitor prometheus server itself
         default_config = {
             'job_name': 'prometheus',

--- a/src/charm.py
+++ b/src/charm.py
@@ -90,7 +90,7 @@ class PrometheusCharm(CharmBase):
                 container.stop("prometheus")
 
             container.start("prometheus")
-            logger.info("Restarted prometheus done")
+            logger.info("Prometheus started")
 
         if self.unit.is_leader():
             self.app.status = ActiveStatus()

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -307,32 +307,6 @@ class TestCharm(unittest.TestCase):
         prometheus_scrape_config = scrape_config(config, 'prometheus')
         self.assertIsNotNone(prometheus_scrape_config, 'No default config found')
 
-    @patch('ops.testing._TestingPebbleClient.push')
-    def test_a_scrape_config_can_be_set(self, push):
-        self.harness.set_leader(True)
-        sconfig = MINIMAL_CONFIG.copy()
-        sconfig['scrape-config'] = """
-        scrape_configs:
-          - job_name: 'kubernetes-apiservers'
-            kubernetes_sd_configs:
-            - role: endpoints
-            scheme: https
-            tls_config:
-              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-            relabel_configs:
-            - source_labels: [__meta_kubernetes_namespace,
-                              __meta_kubernetes_service_name,
-                              __meta_kubernetes_endpoint_port_name]
-            action: keep
-            regex: default;kubernetes;https
-        """
-        self.harness.update_config(sconfig)
-        config = push.call_args[0]
-        job_config = scrape_config(config, 'kubernetes-apiservers')
-        self.assertIsNotNone(job_config, 'No default config found')
-        self.assertEqual(job_config["job_name"], "kubernetes-apiservers")
-
 
 def alerting_config(config):
     config_yaml = config[1]


### PR DESCRIPTION
1. Removing support for adding a Prometheus configuration using Juju command line. Also updated README accordingly.
2. Minor grammatical and spelling fixes.