### PR TITLE
remove concat of alertmanager api port

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -29,7 +29,6 @@ class PrometheusCharm(CharmBase):
         super().__init__(*args)
 
         self._stored.set_default(alertmanagers=[])
-        self._stored.set_default(alertmanager_port='9093')
         self._stored.set_default(provider_ready=False)
         self._stored.set_default(prometheus_config_hash=None)
 
@@ -143,9 +142,7 @@ class PrometheusCharm(CharmBase):
             return
 
         addrs = json.loads(event.relation.data[event.app].get('addrs', '[]'))
-        port = event.relation.data[event.app]['port']
 
-        self._stored.alertmanager_port = port
         self._stored.alertmanagers = addrs
 
         self._on_config_changed(event)
@@ -336,11 +333,7 @@ class PrometheusCharm(CharmBase):
             logger.debug('No alertmanagers available')
             return alerting_config
 
-        targets = []
-        for manager in self._stored.alertmanagers:
-            port = self._stored.alertmanager_port
-            targets.append("{}:{}".format(manager, port))
-
+        targets = [manager for manager in self._stored.alertmanagers]
         manager_config = {'static_configs': [{'targets': targets}]}
         alerting_config = {'alertmanagers': [manager_config]}
 

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -68,8 +68,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_relation_data(rel_id,
                                           'alertmanager',
                                           {
-                                              'port': '9093',
-                                              'addrs': '["192.168.0.1"]'
+                                              'addrs': '["192.168.0.1:9093"]'
                                           })
         config = push.call_args[0]
         self.assertEqual(alerting_config(config), SAMPLE_ALERTING_CONFIG)
@@ -87,8 +86,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_relation_data(rel_id,
                                           'alertmanager',
                                           {
-                                              'port': '9093',
-                                              'addrs': '["192.168.0.1"]'
+                                              'addrs': '["192.168.0.1:9093"]'
                                           })
         config = push.call_args[0]
         self.assertEqual(alerting_config(config), SAMPLE_ALERTING_CONFIG)


### PR DESCRIPTION
This change removes any concern of Alertmanager's API port from the prometheus operator.
The prometheus operator should not concern itself with concatenating Alertmanager's API port because:
1. Alertmanager is perfectly capable of concatenating the port to the address on its own.
2. In the most general case, the Alertmanager API port may vary across replicas, and the current implementation in prometheus expects a scalar for `port`, not a vector or mapping.