### PR TITLE
Default http port is not special

### DIFF
--- a/lib/charms/prometheus/v1/prometheus.py
+++ b/lib/charms/prometheus/v1/prometheus.py
@@ -76,7 +76,7 @@ class PrometheusConsumer(ConsumerBase):
         if address in targets:
             return
 
-        target = address if port == 80 else address + ":" + str(port)
+        target = address + ":" + str(port)
         targets.append(target)
         self._update_targets(targets, rel_id)
 


### PR DESCRIPTION
This commit removes a redundant ternary operator that
was left over from an early development version of the
code and overlooked.