### PR TITLE
Updated charm name with deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ separate Charm.
 
 ## Usage
 
+The Prometheus Operator may be deployed using the Juju commandline as
+in
+
+    juju deploy prometheus-k8s
+
 By default the Prometheus Operator monitors itself, but it also
 accepts additional scrape targets over Juju relations with charms that
 support the `prometheus` interface and preferably use the Prometheus

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,4 @@
-name: prometheus
+name: prometheus-k8s
 summary: Prometheus for Kubernetes clusters
 maintainers:
     - Balbir Thomas <balbir.thomas@canonical.com>


### PR DESCRIPTION
This commit changes the name of the charm to confirm with the
standard for Kubernetes charms. Also the readme file is updated
to add deployment instructions.