### PR TITLE
Removing unused code

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,3 +1,0 @@
-reload-config:
-  description: |
-    Tell Prometheus to reload its config from the ConfigMap.

--- a/actions/reload-config
+++ b/actions/reload-config
@@ -1,2 +1,0 @@
-#!/bin/sh
-kill -HUP 1 && echo "Sent SIGHUP to the Prometheus container, config reloaded"

--- a/config.yaml
+++ b/config.yaml
@@ -3,16 +3,6 @@ options:
     description: The port prometheus will be listening on
     type: int
     default: 9090
-  ssl-cert:
-    type: string
-    default:
-    description: |
-      SSL certificate to install and use for Prometheus endpoint.
-  ssl-key:
-    type: string
-    default:
-    description: |
-      SSL key to use with certificate specified as ssl-cert.
   log-level:
     description: |
       Prometheus server log level (only log messages with the given severity

--- a/config.yaml
+++ b/config.yaml
@@ -1,16 +1,4 @@
 options:
-  prometheus-image-username:
-    type: string
-    description: |
-      The username for accessing the registry specified in
-      prometheus-image-path.
-    default: ""
-  prometheus-image-password:
-    type: string
-    description: |
-      The password associated with prometheus-image-username for
-      accessing the registry specified in prometheus-image-path.
-    default: ""
   port:
     description: The port prometheus will be listening on
     type: int

--- a/src/charm.py
+++ b/src/charm.py
@@ -413,12 +413,7 @@ class PrometheusCharm(CharmBase):
             a list of missing configuration items (configuration keys)
         """
         logger.debug('Checking Config')
-        config = self.model.config
         missing = []
-
-        if config.get('prometheus-image-username') \
-                and not config.get('prometheus-image-password'):
-            missing.append('prometheus-image-password')
 
         return missing
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -76,15 +76,6 @@ class PrometheusCharm(CharmBase):
         logger.info("Configuring Prometheus")
         container = self.unit.get_container("prometheus")
 
-        # validate configuration options
-        missing_config = self._check_config()
-        if missing_config:
-            logger.error('Incomplete Configuration : {}. '
-                         'Application will be blocked.'.format(missing_config))
-            self.unit.status = \
-                BlockedStatus('Missing configuration: {}'.format(missing_config))
-            return
-
         # check if configuration file has changed and if so push the
         # new config file to the workload container
         prometheus_config = self._prometheus_config()
@@ -405,17 +396,6 @@ class PrometheusCharm(CharmBase):
         }
 
         return layer
-
-    def _check_config(self):
-        """Identify missing but required items in configuation
-
-        Returns:
-            a list of missing configuration items (configuration keys)
-        """
-        logger.debug('Checking Config')
-        missing = []
-
-        return missing
 
     @property
     def version(self):

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -30,26 +30,6 @@ class TestCharm(unittest.TestCase):
         self.harness.begin()
 
     @patch('ops.testing._TestingPebbleClient.push')
-    def test_password_is_required_when_username_is_set(self, _):
-        self.harness.set_leader(True)
-
-        missing_password_config = {
-            'prometheus-image-username': 'some-user',
-            'prometheus-image-password': '',
-        }
-        with self.assertLogs(level='ERROR') as logger:
-            self.harness.update_config(missing_password_config)
-            expected_logs = [
-                "ERROR:charm:Incomplete Configuration : ['prometheus-image-password']. "
-                "Application will be blocked."
-            ]
-            self.assertEqual(sorted(logger.output), expected_logs)
-
-        missing = self.harness.charm._check_config()
-        expected = ['prometheus-image-password']
-        self.assertEqual(missing, expected)
-
-    @patch('ops.testing._TestingPebbleClient.push')
     def test_alerting_config_is_updated_by_alertmanager_relation(self, push):
         self.harness.set_leader(True)
 


### PR DESCRIPTION
1. Remove now redundant image username and password
2. Remove redundant check config
3. Remove redundant action
4. Remove unimplemented ssl cert and key

closes https://github.com/canonical/prometheus-operator/issues/45 https://github.com/canonical/prometheus-operator/issues/43