### PR TITLE
Add coverage to tests, add display-name for nicer display on Charmhub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *swp
 *.charm
+.coverage
 __pycache__
 build
 venv

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,5 @@
 name: prometheus-k8s
+display-name: Prometheus
 summary: Prometheus for Kubernetes clusters
 maintainers:
     - Balbir Thomas <balbir.thomas@canonical.com>

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 black
+coverage
 flake8
 pytest
 pytest-cov

--- a/run_tests
+++ b/run_tests
@@ -13,5 +13,5 @@ else
 fi
 
 black --diff
-coverage run --branch --source=lib,src -m unittest -v "$@"
+coverage run --branch --source=src,lib/charms/prometheus_k8s -m unittest -v "$@"
 coverage report -m

--- a/run_tests
+++ b/run_tests
@@ -13,4 +13,5 @@ else
 fi
 
 black --diff
-python3 -m unittest -v "$@"
+coverage run --branch --source=lib,src -m unittest -v "$@"
+coverage report -m


### PR DESCRIPTION
The charmcraft init template now includes coverage, update this charm to include that.

Also add a "display-name" in metadata.yaml so the name of the charm is correctly displayed on https://charmhub.io