### PR TITLE
Remove spurious quotes when relations are broken

### DIFF
--- a/lib/charms/prometheus_k8s/v1/prometheus.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus.py
@@ -247,7 +247,7 @@ class PrometheusProvider(ProviderBase):
 
         job_config = {"job_name": job_name, "static_configs": [{"targets": targets}]}
 
-        self._stored.jobs["rel_id"] = json.dumps(job_config)
+        self._stored.jobs[rel_id] = json.dumps(job_config)
         logger.debug("New job config on relation change : %s", job_config)
         self.on.targets_changed.emit()
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -46,7 +46,7 @@ class TestProvider(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id, "target", {"targets": json.dumps([target_ip])}
         )
-        jobs = self.harness.charm.prometheus_provider._stored.jobs["rel_id"]
+        jobs = self.harness.charm.prometheus_provider._stored.jobs[rel_id]
         jobs = json.loads(jobs)
         self.assertIsNotNone(jobs)
         static_configs = jobs.get("static_configs", None)


### PR DESCRIPTION
There is no key named "rel_id", and this will always result in a KeyError. Remove the quotes so lookups work as expected