### PR TITLE
Juju topology

### DIFF
--- a/lib/charms/prometheus_k8s/v1/prometheus.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus.py
@@ -249,6 +249,9 @@ class PrometheusProvider(ProviderBase):
         Returns:
             A static scrape configuration for a specific relation.
         """
+        if len(relation.units) == 0:
+            return {}
+
         scrape_metadata = json.loads(
             relation.data[relation.app].get("prometheus_scrape_metadata")
         )

--- a/lib/charms/prometheus_k8s/v1/prometheus.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus.py
@@ -377,27 +377,27 @@ class PrometheusProvider(ProviderBase):
         if len(relation.units) == 0:
             return []
 
-        scrape_jobs = json.loads(
-            relation.data[relation.app].get("scrape_jobs")
-        )
+        scrape_jobs = json.loads(relation.data[relation.app].get("scrape_jobs"))
 
         if not scrape_jobs:
             return []
 
-        scrape_metadata = json.loads(
-            relation.data[relation.app].get("scrape_metadata")
-        )
+        scrape_metadata = json.loads(relation.data[relation.app].get("scrape_metadata"))
 
         job_name_prefix = "juju_{}_{}_{}_prometheus_{}_scrape".format(
-            scrape_metadata["model"], scrape_metadata["model_uuid"][:7],
-            scrape_metadata["application"], relation.id
+            scrape_metadata["model"],
+            scrape_metadata["model_uuid"][:7],
+            scrape_metadata["application"],
+            relation.id,
         )
 
         hosts = self._relation_hosts(relation)
 
         labeled_job_configs = []
         for job in scrape_jobs:
-            config = self._labeled_static_job_config(job, job_name_prefix, hosts, scrape_metadata)
+            config = self._labeled_static_job_config(
+                job, job_name_prefix, hosts, scrape_metadata
+            )
             labeled_job_configs.append(config)
 
         return labeled_job_configs
@@ -467,13 +467,15 @@ class PrometheusProvider(ProviderBase):
                     unitless_targets.append(target)
 
             if unitless_targets:
-                unitless_config = self._labeled_unitless_config(unitless_targets,
-                                                                labels, scrape_metadata)
+                unitless_config = self._labeled_unitless_config(
+                    unitless_targets, labels, scrape_metadata
+                )
                 config["static_configs"].append(unitless_config)
 
             for host_name, host_address in hosts.items():
-                static_config = self._labeled_unit_config(host_name, host_address,
-                                                          ports, labels, scrape_metadata)
+                static_config = self._labeled_unit_config(
+                    host_name, host_address, ports, labels, scrape_metadata
+                )
                 config["static_configs"].append(static_config)
 
         return config
@@ -520,13 +522,12 @@ class PrometheusProvider(ProviderBase):
             for a list of fully qualified hosts.
         """
         juju_labels = self._set_juju_labels(labels, scrape_metadata)
-        unitless_config = {
-            "targets": targets,
-            "labels": juju_labels
-        }
+        unitless_config = {"targets": targets, "labels": juju_labels}
         return unitless_config
 
-    def _labeled_unit_config(self, host_name, host_address, ports, labels, scrape_metadata):
+    def _labeled_unit_config(
+        self, host_name, host_address, ports, labels, scrape_metadata
+    ):
         """Static scrape configuration for a wildcard host.
 
         Wildcard hosts are those scrape targets whose address is
@@ -607,9 +608,7 @@ class PrometheusConsumer(ConsumerBase):
 
         events = self._charm.on[self._relation_name]
         self.framework.observe(events.relation_joined, self._set_scrape_metadata)
-        self.framework.observe(
-            self._service_event, self._set_unit_ip
-        )
+        self.framework.observe(self._service_event, self._set_unit_ip)
 
     def _set_scrape_metadata(self, event):
         """Ensure scrape targets metadata is made available to Prometheus.
@@ -654,11 +653,7 @@ class PrometheusConsumer(ConsumerBase):
            A list of dictionaries, where each dictionary specifies a
            single scrape job for Prometheus.
         """
-        default_job = [
-            {
-                "metrics_path": "/metrics"
-            }
-        ]
+        default_job = [{"metrics_path": "/metrics"}]
         return self._jobs if self._jobs else default_job
 
     @property

--- a/lib/charms/prometheus_k8s/v1/prometheus.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus.py
@@ -246,15 +246,14 @@ class PrometheusProvider(ProviderBase):
             A static scrape configuration for a specific relation.
         """
         scrape_metadata = json.loads(
-            relation.data[relation.app].get("prometheus_scrape_metadata"))
+            relation.data[relation.app].get("prometheus_scrape_metadata")
+        )
 
         if not scrape_metadata:
             return None
 
         job_name = "juju_prometheus_scrape_{}_{}_{}".format(
-            scrape_metadata["model"],
-            scrape_metadata["application"],
-            relation.id
+            scrape_metadata["model"], scrape_metadata["application"], relation.id
         )
 
         hosts = {}
@@ -267,20 +266,21 @@ class PrometheusProvider(ProviderBase):
         scrape_config = {
             "job_name": job_name,
             "metrics_path": scrape_metadata["static_scrape_path"],
-            "static_configs": []
+            "static_configs": [],
         }
 
         for host_name, host_address in hosts.items():
-            metrics_url = "{}:{}".format(host_address,
-                                         scrape_metadata["static_scrape_port"])
+            metrics_url = "{}:{}".format(
+                host_address, scrape_metadata["static_scrape_port"]
+            )
 
             config = {
                 "targets": [metrics_url],
                 "labels": {
                     "juju_model": "{}".format(scrape_metadata["model"]),
                     "juju_application": "{}".format(scrape_metadata["application"]),
-                    "juju_unit": "{}".format(host_name)
-                }
+                    "juju_unit": "{}".format(host_name),
+                },
             }
             scrape_config["static_configs"].append(config)
 
@@ -288,7 +288,6 @@ class PrometheusProvider(ProviderBase):
 
 
 class PrometheusConsumer(ConsumerBase):
-
     def __init__(self, charm, name, consumes, service, config={}, multi=False):
         """Construct a Prometheus charm client.
 
@@ -329,8 +328,9 @@ class PrometheusConsumer(ConsumerBase):
 
         events = self._charm.on[self._relation_name]
         self.framework.observe(events.relation_joined, self._set_scrape_metadata)
-        self.framework.observe(self._charm.on[self._service].pebble_ready,
-                               self._set_unit_ip)
+        self.framework.observe(
+            self._charm.on[self._service].pebble_ready, self._set_unit_ip
+        )
 
     def _set_scrape_metadata(self, event):
         """Ensure scrape targets metadata is made available to Prometheus.
@@ -342,13 +342,15 @@ class PrometheusConsumer(ConsumerBase):
         host address in Juju unit relation data.
         """
         event.relation.data[self._charm.unit]["prometheus_scrape_host"] = str(
-            self._charm.model.get_binding(event.relation).network.bind_address)
+            self._charm.model.get_binding(event.relation).network.bind_address
+        )
 
         if not self._charm.unit.is_leader():
             return
 
-        event.relation.data[self._charm.app][
-            "prometheus_scrape_metadata"] = json.dumps(self._scrape_metadata)
+        event.relation.data[self._charm.app]["prometheus_scrape_metadata"] = json.dumps(
+            self._scrape_metadata
+        )
 
     def _set_unit_ip(self, event):
         """Set unit host address
@@ -358,7 +360,8 @@ class PrometheusConsumer(ConsumerBase):
         """
         for relation in self._charm.model.relations[self._relation_name]:
             relation.data[self._charm.unit]["prometheus_scrape_host"] = str(
-                self._charm.model.get_binding(relation).network.bind_address)
+                self._charm.model.get_binding(relation).network.bind_address
+            )
 
     @property
     def _scrape_metadata(self):
@@ -371,6 +374,6 @@ class PrometheusConsumer(ConsumerBase):
             "model": "{}".format(self._charm.model.name),
             "application": "{}".format(self._charm.model.app.name),
             "static_scrape_port": self._static_scrape_port,
-            "static_scrape_path": self._static_scrape_path
+            "static_scrape_path": self._static_scrape_path,
         }
         return metadata

--- a/lib/charms/prometheus_k8s/v1/prometheus.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus.py
@@ -478,6 +478,27 @@ class PrometheusProvider(ProviderBase):
 
         return config
 
+    def _set_juju_labels(self, labels, scrape_metadata):
+        """Create a copy of metric labels with Juju topology information.
+
+        Args:
+
+            labels: a dictionary containing Prometheus metric labels.
+            scrape_metadata: scrape related metadata provied by
+                `PrometheusConsumer`.
+
+        Returns:
+
+            a copy of the `labels` dictionary augmented with Juju
+            topology information with the exception of unit name.
+        """
+        juju_labels = labels.copy()  # deep copy not needed
+        juju_labels["juju_model"] = "{}".format(scrape_metadata["model"])
+        juju_labels["juju_model_uuid"] = "{}".format(scrape_metadata["model_uuid"])
+        juju_labels["juju_application"] = "{}".format(scrape_metadata["application"])
+
+        return juju_labels
+
     def _labeled_unitless_config(self, targets, labels, scrape_metadata):
         """Static scrape configuration for fully qualified host addresses.
 
@@ -498,10 +519,7 @@ class PrometheusProvider(ProviderBase):
             A dictionary containing the static scrape configuration
             for a list of fully qualified hosts.
         """
-        juju_labels = labels.copy()  # deep copy not needed
-        juju_labels["juju_model"] = "{}".format(scrape_metadata["model"])
-        juju_labels["juju_model_uuid"] = "{}".format(scrape_metadata["model_uuid"])
-        juju_labels["juju_application"] = "{}".format(scrape_metadata["application"])
+        juju_labels = self._set_juju_labels(labels, scrape_metadata)
         unitless_config = {
             "targets": targets,
             "labels": juju_labels
@@ -529,10 +547,7 @@ class PrometheusProvider(ProviderBase):
             A dictionary containing the static scrape configuration
             for a single wildcard host.
         """
-        juju_labels = labels.copy()  # deep copy not needed
-        juju_labels["juju_model"] = "{}".format(scrape_metadata["model"])
-        juju_labels["juju_model_uuid"] = "{}".format(scrape_metadata["model_uuid"])
-        juju_labels["juju_application"] = "{}".format(scrape_metadata["application"])
+        juju_labels = self._set_juju_labels(labels, scrape_metadata)
         juju_labels["juju_unit"] = "{}".format(host_name)
 
         static_config = {"labels": juju_labels}

--- a/lib/charms/prometheus_k8s/v1/prometheus.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus.py
@@ -15,22 +15,25 @@ This Prometheus charm interacts with its scrape targets using its
 charm library. This charm library is constructed using the [Provider
 and
 Consumer](https://ops.readthedocs.io/en/latest/#module-ops.relation)
-objects from the Operator Framework. This implies charms that would
-like to expose metric endpoints for the Prometheus charm must use the
-`PrometheusConsumer` object from the charm library to do so. Using the
-`PrometheusConsumer` object requires instantiating it, typically in
-the constructor of your charm (the one which exposes the metrics
-endpoint). The `PrometheusConsumer` constructor requires the name of
-the relation over which a scrape target (metrics endpoint) is exposed
-to the Promtheus charm. This relation must use the `prometheus_scrape`
-interface. The address of the metrics endpoint is set to the unit
-address, by each unit of the consumer charm. Hence instantiating the
-consumer also requires providing it the Pebble service name of the
-consumer. In addition the constructor also requires a `consumes`
-specification, which is a dictionary with key `prometheus` (also see
-Provider Library Usage below) and a value that represents the minimum
-acceptable version of Prometheus. This version string can be in any
-format that is compatible with Python [Semantic Version
+objects from the Operator Framework. This implies charms seeking to
+expose a metric endpoints for the Prometheus charm, must do so using
+the `PrometheusConsumer` object from this charm library. For the
+simplest use case using the `PrometheusConsumer` object only requires
+instantiating it, typically in the constructor of your charm (the one
+which exposes the metrics endpoint). The `PrometheusConsumer`
+constructor requires the name of the relation over which a scrape
+target (metrics endpoint) is exposed to the Prometheus charm. This is
+relation that must use the `prometheus_scrape` interface. The address
+of the metrics endpoint is set to the unit address, by each unit of
+the consumer charm. These units set their address in response to a
+`CharmEvent`. Hence instantiating the `PrometheusConsumer` also requires
+a `CharmEvent` object in response to which each unit will post its address
+into the unit's relation data for the Prometheus charm. In addition the
+constructor also requires a `consumes` specification, which is a
+dictionary with key `prometheus` (also see Provider Library Usage
+below) and a value that represents the minimum acceptable version of
+Prometheus. This version string can be in any format that is
+compatible with Python [Semantic Version
 module](https://pypi.org/project/semantic-version/).  For example,
 assuming your charm exposes a metrics endpoint over a relation named
 "monitoring", you may instantiate `PrometheusConsumer` as follows
@@ -40,10 +43,14 @@ assuming your charm exposes a metrics endpoint over a relation named
     def __init__(self, *args):
         super().__init__(*args)
         ...
-        self.prometheus = PrometheusConsumer(self, "monitoring", {"prometheus": ">=2.0"})
+        self.prometheus = PrometheusConsumer(self, "monitoring",
+                                             {"prometheus": ">=2.0"}
+                                             self.on.my_service_pebble_ready)
         ...
 
-This example hard codes the consumes dictionary argument containing the
+In this example `my_service_pebble_ready` is the `PebbleReady` event
+in response to which each unit will advertise its address. Also this
+example hard codes the consumes dictionary argument containing the
 minimal Prometheus version required, however you may want to consider
 generating this dictionary by some other means, such as a
 `self.consumes` property in your charm. This is because the minimum
@@ -57,12 +64,120 @@ An instantiated `PrometheusConsumer` object will ensure that each unit
 of the consumer charm, is a scrape target for the
 `PrometheusProvider`. By default `PrometheusConsumer` assumes each
 unit of the consumer charm exports its metrics at a path given by
-`/metrics` on port 80. This is the default behaviour off most
+`/metrics` on port 80. This is the default behaviour of most
 Prometheus metrics exporters so typically the defaults do not need to
 be changed. However if required the defaults may be changed by
 providing the `PrometheusConsumer` constructor an optional argument
-(`config`) that represents its configuration in Python dictionary
-format.
+(`jobs`) that represents a Prometheus job specification using Python
+standard data structures. This job specification is a rich subset of
+Prometheus' own [scrape
+configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config)
+format but represented using Python data structures. More than one job
+may be provided using the `jobs` argument. Hence `jobs` accepts a list
+of dictionaries where each dictionary represents one `<scrape_config>`
+object as described in the Prometheus documentation. However service
+discovery configuration types are forbidden, and only static scrape
+configurations are enabled. Also authorisation, authentication and
+encryption related configurations are currently not supported.
+
+Suppose it is required to change the port on which scraped metrics are
+exposed to 8000. This may be done by providing the following data
+structure as the value of `jobs`.
+
+```
+[
+    {
+        "static_configs": [
+            {
+                "targets": ["*:8000"],
+            }
+        ]
+    }
+]
+```
+
+The wildcard ("*") host specification implies that the scrape targets
+will automatically be set to the host addresses advertised by each
+unit of the consumer charm.
+
+It is also possible to change the metrics path and scrape multiple
+ports, for example
+
+```
+[
+    {
+        "metrics_path": "/my-metrics-path",
+        "static_configs": [
+            {
+                "targets": ["*:8000", "*:8081"],
+            }
+        ]
+    }
+]
+```
+
+More complex scrape configurations are possible. For example
+
+```
+[
+    {
+        "static_configs": [
+            {
+                "targets": ["10.1.32.215:7000", "*:8000"],
+                "labels": {
+                    "some-key": "some-value"
+                }
+            }
+        ]
+    }
+]
+```
+
+This example scrapes the target "10.1.32.215" at port 7000 in addition
+to scraping each unit at port 8000. There is however one difference
+between wildcard targets (specified using "*") and fully qualified
+targets (such as "10.1.32.215"). The Prometheus charm automatically
+associates labels with metrics generated by each target. These labels
+localise the source of metrics within the Juju topology by specifying
+its "model name", "model UUID", "application name" and "unit
+name". However unit name is associated only with wildcard targets but
+not with fully qualified targets.
+
+Multiple jobs with different metrics paths and labels are allowed, but
+each job must be given a unique name. For example
+
+```
+[
+    {
+        "job_name": "my-first-job",
+        "metrics_path": "one-path",
+        "static_configs": [
+            {
+                "targets": ["*:7000"],
+                "labels": {
+                    "some-key": "some-value"
+                }
+            }
+        ]
+    },
+    {
+        "job_name": "my-second-job",
+        "metrics_path": "another-path"
+        "static_configs": [
+            {
+                "targets": ["*:8000"],
+                "labels": {
+                    "some-other-key": "some-other-value"
+                }
+            }
+        ]
+    }
+]
+```
+
+It is also possible to configure other scrape related parameters using
+these job specifications as described by the Prometheus
+[documentation](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).
 
 ## Provider Library Usage
 
@@ -129,10 +244,16 @@ by `jobs()` as follows
 
 ## Relation Data
 
-The Prometheus charm uses application relation data to obtain its list
-of scrape targets. This relation data is in JSON format and it closely
-resembles the YAML structure of Prometheus [scrape configuration]
+The Prometheus charm uses both application and unit relation data to
+obtain information regarding its scrape jobs and scrape targets. This
+relation data is in JSON format and it closely resembles the YAML
+structure of Prometheus [scrape configuration]
 (https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).
+
+Units of consumer charm advertise their address over unit relation
+data using the `prometheus_scrape_host` key. While the
+`scrape_metadata` and `scrape_jobs` keys in application relation data
+provide eponymous information.
 """
 
 import json
@@ -175,6 +296,7 @@ class PrometheusProvider(ProviderBase):
         """A Prometheus based Monitoring service provider.
 
         Args:
+
             charm: a `CharmBase` instance that manages this
                 instance of the Prometheus service.
             name: string name of the relation that is provides the
@@ -240,24 +362,27 @@ class PrometheusProvider(ProviderBase):
         return scrape_jobs
 
     def _static_scrape_config(self, relation):
-        """Generate the static scrape configuration for a relation.
+        """Generate the static scrape configuration for a single relation.
 
         Args:
             relation: an `ops.model.Relation` object whose static
                 scrape configuration is required.
 
         Returns:
-            A static scrape configuration for a specific relation.
+
+            A list (possibly empty) of scrape jobs. Each job is a
+            valid Prometheus scrape configuration for that job,
+            represented as a Python dictionary.
         """
         if len(relation.units) == 0:
-            return None
+            return []
 
         scrape_jobs = json.loads(
             relation.data[relation.app].get("scrape_jobs")
         )
 
         if not scrape_jobs:
-            return None
+            return []
 
         scrape_metadata = json.loads(
             relation.data[relation.app].get("scrape_metadata")
@@ -278,6 +403,18 @@ class PrometheusProvider(ProviderBase):
         return labeled_job_configs
 
     def _relation_hosts(self, relation):
+        """Fetch host names and address of all consumer units for a single relation.
+
+        Args:
+
+            relation: An `ops.model.Relation` object for which the host name to
+                address mapping is required.
+
+        Returns:
+
+            A dictionary that maps unit names to unit addresses for
+            the specified relation.
+        """
         hosts = {}
         for unit in relation.units:
             host_address = relation.data[unit].get("prometheus_scrape_host")
@@ -287,6 +424,27 @@ class PrometheusProvider(ProviderBase):
         return hosts
 
     def _labeled_static_job_config(self, job, job_name_prefix, hosts, scrape_metadata):
+        """Construct labeled job configuration for a single job.
+
+        Args:
+
+            job: a dictionary representing the job configuration as obtained from
+                `PrometheusConsumer` over relation data.
+            job_name_prefix: a string that may either be used as the
+                job name if none is provided or used as a prefix for
+                the provided job name.
+            hosts: a dictionary mapping host names to host address for
+                all units of the relation for which this job configuration
+                must be constructed.
+            scrape_metadata: scrape configuration metadata obtained
+                from `PrometheusConsumer` from the same relation for
+                which this job configuration is being constructed.
+
+        Returns:
+
+            A dictionary representing a Prometheus job configuration
+            for a single job.
+        """
         name = job.get("job_name")
         job_name = "job_name_prefix_{}".format(name) if name else job_name_prefix
 
@@ -321,6 +479,25 @@ class PrometheusProvider(ProviderBase):
         return config
 
     def _labeled_unitless_config(self, targets, labels, scrape_metadata):
+        """Static scrape configuration for fully qualified host addresses.
+
+        Fully qualified hosts are those scrape targets for which the
+        address are not automatically determined by
+        `PrometheusProvider` but instead are specified by the client
+        of `PrometheusConsumer`.
+
+        Args:
+
+            targets: a list of addresses of fully qualified hosts.
+            labels: labels specified by `PrometheusConsumer` clients
+                 which are associated with `targets`.
+            scrape_metadata: scrape related metadata provied by `PrometheusConsumer`.
+
+        Returns:
+
+            A dictionary containing the static scrape configuration
+            for a list of fully qualified hosts.
+        """
         juju_labels = labels.copy()  # deep copy not needed
         juju_labels["juju_model"] = "{}".format(scrape_metadata["model"])
         juju_labels["juju_model_uuid"] = "{}".format(scrape_metadata["model_uuid"])
@@ -332,6 +509,26 @@ class PrometheusProvider(ProviderBase):
         return unitless_config
 
     def _labeled_unit_config(self, host_name, host_address, ports, labels, scrape_metadata):
+        """Static scrape configuration for a wildcard host.
+
+        Wildcard hosts are those scrape targets whose address is
+        automatically determined by `PrometheusProvider`.
+
+        Args:
+
+            host_name: a string representing the unit name of the wildcard host.
+            host_address: a string representing the address of the wildcard host.
+            ports: list of ports on which this wildcard host exposes its metrics.
+            labels: a dictionary of labels provided by
+                `PrometheusConsumer` intended to be associated with
+                this wildcard host.
+            scrape_metadata: scrape related metadata provied by `PrometheusConsumer`.
+
+        Returns:
+
+            A dictionary containing the static scrape configuration
+            for a single wildcard host.
+        """
         juju_labels = labels.copy()  # deep copy not needed
         juju_labels["juju_model"] = "{}".format(scrape_metadata["model"])
         juju_labels["juju_model_uuid"] = "{}".format(scrape_metadata["model_uuid"])
@@ -359,7 +556,9 @@ class PrometheusConsumer(ConsumerBase):
         Prometheus. Any charm instantiating this object has metrics
         from each of its units aggregated by a related Prometheus
         charm
-            self.prometheus = PrometheusConsumer(self, "monitoring", {"prometheus": ">=2.0"})
+            self.prometheus = PrometheusConsumer(self, "monitoring",
+                                                 {"prometheus": ">=2.0"}
+                                                 self.my_service_pebble_ready)
         Args:
 
             charm: a `CharmBase` object that manages this
@@ -374,8 +573,11 @@ class PrometheusConsumer(ConsumerBase):
                 dictionary are corresponding minimal acceptable
                 semantic version specfications for the monitoring
                 service.
-            service: string name of Pebble service of consumer charm.
-            jobs: an optional list of jobs along with their configuration
+            service: a `CharmEvent` in response to which each unit
+                must advertise its address.
+            jobs: an optional list of dictionaries where each
+                dictionary represents the Prometheus scrape configuration
+                for a single job.
             multi: an optional (default False) flag to indicate if
                 this object must support interaction with multiple
                 Prometheus monitoring service providers.
@@ -430,6 +632,13 @@ class PrometheusConsumer(ConsumerBase):
 
     @property
     def _scrape_jobs(self):
+        """Fetch list of scrape jobs.
+
+        Returns:
+
+           A list of dictionaries, where each dictionary specifies a
+           single scrape job for Prometheus.
+        """
         default_job = [
             {
                 "metrics_path": "/metrics"
@@ -442,6 +651,7 @@ class PrometheusConsumer(ConsumerBase):
         """Generate scrape metadata.
 
         Returns:
+
             Scrape configutation metadata for this Prometheus consumer charm.
         """
         metadata = {

--- a/lib/charms/prometheus_k8s/v1/prometheus.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus.py
@@ -208,7 +208,7 @@ class PrometheusProvider(ProviderBase):
             events.relation_changed, self._on_scrape_target_relation_changed
         )
         self.framework.observe(
-            events.relation_broken, self._on_scrape_target_relation_broken
+            events.relation_departed, self._on_scrape_target_relation_departed
         )
 
     def _on_scrape_target_relation_changed(self, event):
@@ -224,7 +224,7 @@ class PrometheusProvider(ProviderBase):
 
         self.on.targets_changed.emit(relation_id=rel_id)
 
-    def _on_scrape_target_relation_broken(self, event):
+    def _on_scrape_target_relation_departed(self, event):
         """Update job config when consumers depart.
 
         When a Prometheus consumer departs the scrape configuration

--- a/lib/charms/prometheus_k8s/v1/prometheus.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus.py
@@ -282,6 +282,7 @@ class PrometheusProvider(ProviderBase):
                 "targets": [metrics_url],
                 "labels": {
                     "juju_model": "{}".format(scrape_metadata["model"]),
+                    "juju_model_uuid": "{}".format(scrape_metadata["model_uuid"]),
                     "juju_application": "{}".format(scrape_metadata["application"]),
                     "juju_unit": "{}".format(host_name),
                 },
@@ -377,6 +378,7 @@ class PrometheusConsumer(ConsumerBase):
         """
         metadata = {
             "model": "{}".format(self._charm.model.name),
+            "model_uuid": "{}".format(self._charm.model.uuid),
             "application": "{}".format(self._charm.model.app.name),
             "static_scrape_port": self._static_scrape_port,
             "static_scrape_path": self._static_scrape_path,

--- a/lib/charms/prometheus_k8s/v1/prometheus.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus.py
@@ -150,7 +150,6 @@ resembles the YAML structure of Prometheus [scrape configuration]
 
 import json
 import logging
-from subprocess import check_output
 from ops.framework import EventSource, EventBase, ObjectEvents
 from ops.relation import ProviderBase, ConsumerBase
 

--- a/lib/charms/prometheus_k8s/v1/prometheus.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus.py
@@ -498,8 +498,8 @@ class PrometheusConsumer(ConsumerBase):
             "static_configs": [{
                 "targets": list(targets),
                 "labels": {
-                    "juju_model_name": "{}".format(self._charm.model.name),
-                    "juju_app_name": "{}".format(self._charm.model.app.name),
+                    "juju_model": "{}".format(self._charm.model.name),
+                    "juju_application": "{}".format(self._charm.model.app.name),
                     "juju_relation_id": "{}".format(rel_id)
                 }
             }]

--- a/lib/charms/prometheus_k8s/v1/prometheus.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus.py
@@ -279,8 +279,7 @@ class PrometheusProvider(ProviderBase):
                 "labels": {
                     "juju_model": "{}".format(scrape_metadata["model"]),
                     "juju_application": "{}".format(scrape_metadata["application"]),
-                    "juju_unit": "{}".format(host_name),
-                    "juju_relation_id": "{}".format(relation.id)
+                    "juju_unit": "{}".format(host_name)
                 }
             }
             scrape_config["static_configs"].append(config)

--- a/lib/charms/prometheus_k8s/v1/prometheus.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus.py
@@ -13,7 +13,8 @@ provide a scrape target for Prometheus.
 
 This Prometheus charm interacts with its scrape targets using its
 charm library. This charm library is constructed using the [Provider
-and Consumer](https://ops.readthedocs.io/en/latest/#module-ops.relation)
+and
+Consumer](https://ops.readthedocs.io/en/latest/#module-ops.relation)
 objects from the Operator Framework. This implies charms that would
 like to expose metric endpoints for the Prometheus charm must use the
 `PrometheusConsumer` object from the charm library to do so. Using the
@@ -22,7 +23,10 @@ the constructor of your charm (the one which exposes the metrics
 endpoint). The `PrometheusConsumer` constructor requires the name of
 the relation over which a scrape target (metrics endpoint) is exposed
 to the Promtheus charm. This relation must use the `prometheus_scrape`
-interface. In addition the constructor also requires a `consumes`
+interface. The address of the metrics endpoint is set to the unit
+address, by each unit of the consumer charm. Hence instantiating the
+consumer also requires providing it the Pebble service name of the
+consumer. In addition the constructor also requires a `consumes`
 specification, which is a dictionary with key `prometheus` (also see
 Provider Library Usage below) and a value that represents the minimum
 acceptable version of Prometheus. This version string can be in any
@@ -310,6 +314,7 @@ class PrometheusConsumer(ConsumerBase):
                 dictionary are corresponding minimal acceptable
                 semantic version specfications for the monitoring
                 service.
+            service: string name of Pebble service of consumer charm.
             config: a optional dictionary with keys that are
                 Prometheus scrape configuration options, for example
                 metrics path and port.

--- a/lib/charms/prometheus_k8s/v1/prometheus.py
+++ b/lib/charms/prometheus_k8s/v1/prometheus.py
@@ -352,7 +352,7 @@ class PrometheusProvider(ProviderBase):
 
 
 class PrometheusConsumer(ConsumerBase):
-    def __init__(self, charm, name, consumes, service, jobs=[], multi=False):
+    def __init__(self, charm, name, consumes, service_event, jobs=[], multi=False):
         """Construct a Prometheus charm client.
 
         The `PrometheusConsumer` object provides an interface to
@@ -383,7 +383,7 @@ class PrometheusConsumer(ConsumerBase):
         super().__init__(charm, name, consumes, multi)
 
         self._charm = charm
-        self._service = service
+        self._service_event = service_event
         self._relation_name = name
         self._jobs = jobs
         self._multi_mode = multi
@@ -391,7 +391,7 @@ class PrometheusConsumer(ConsumerBase):
         events = self._charm.on[self._relation_name]
         self.framework.observe(events.relation_joined, self._set_scrape_metadata)
         self.framework.observe(
-            self._charm.on[self._service].pebble_ready, self._set_unit_ip
+            self._service_event, self._set_unit_ip
         )
 
     def _set_scrape_metadata(self, event):

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -29,7 +29,8 @@ class ConsumerCharm(CharmBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args)
         self.provider = PrometheusConsumer(
-            self, "monitoring", consumes=CONSUMES, service=CONSUMER_SERVICE
+            self, "monitoring", consumes=CONSUMES,
+            service_event=self.on.prometheus_tester_pebble_ready
         )
 
 
@@ -45,12 +46,11 @@ class TestLibrary(unittest.TestCase):
         rel_id = self.harness.add_relation("monitoring", "provider")
         self.harness.add_relation_unit(rel_id, "provider/0")
         data = self.harness.get_relation_data(rel_id, self.harness.model.app.name)
-        self.assertIn("prometheus_scrape_metadata", data)
-        scrape_metadata = data["prometheus_scrape_metadata"]
+        self.assertIn("scrape_metadata", data)
+        scrape_metadata = data["scrape_metadata"]
         self.assertIn("model", scrape_metadata)
+        self.assertIn("model_uuid", scrape_metadata)
         self.assertIn("application", scrape_metadata)
-        self.assertIn("static_scrape_port", scrape_metadata)
-        self.assertIn("static_scrape_path", scrape_metadata)
 
     @patch("ops.testing._TestingModelBackend.network_get")
     def test_consumer_unit_sets_bind_address_on_pebble_ready(self, mock_net_get):

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -29,8 +29,10 @@ class ConsumerCharm(CharmBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args)
         self.provider = PrometheusConsumer(
-            self, "monitoring", consumes=CONSUMES,
-            service_event=self.on.prometheus_tester_pebble_ready
+            self,
+            "monitoring",
+            consumes=CONSUMES,
+            service_event=self.on.prometheus_tester_pebble_ready,
         )
 
 

--- a/tests/test_consumer.py
+++ b/tests/test_consumer.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from ops.charm import CharmBase
 from ops.framework import StoredState
+
 # from ops.model import Network
 from ops.testing import Harness
 from charms.prometheus_k8s.v1.prometheus import PrometheusConsumer
@@ -27,9 +28,9 @@ class ConsumerCharm(CharmBase):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args)
-        self.provider = PrometheusConsumer(self, "monitoring",
-                                           consumes=CONSUMES,
-                                           service=CONSUMER_SERVICE)
+        self.provider = PrometheusConsumer(
+            self, "monitoring", consumes=CONSUMES, service=CONSUMER_SERVICE
+        )
 
 
 class TestLibrary(unittest.TestCase):
@@ -59,13 +60,10 @@ class TestLibrary(unittest.TestCase):
                 {
                     "interface-name": "eth0",
                     "addresses": [
-                        {
-                            "hostname": "prometheus-tester-0",
-                            "value": bind_address,
-                        },
-                    ]
+                        {"hostname": "prometheus-tester-0", "value": bind_address}
+                    ],
                 }
-            ],
+            ]
         }
         mock_net_get.return_value = fake_network
         rel_id = self.harness.add_relation("monitoring", "provider")
@@ -82,13 +80,10 @@ class TestLibrary(unittest.TestCase):
                 {
                     "interface-name": "eth0",
                     "addresses": [
-                        {
-                            "hostname": "prometheus-tester-0",
-                            "value": bind_address,
-                        },
-                    ]
+                        {"hostname": "prometheus-tester-0", "value": bind_address}
+                    ],
                 }
-            ],
+            ]
         }
         mock_net_get.return_value = fake_network
         rel_id = self.harness.add_relation("monitoring", "provider")

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -13,9 +13,19 @@ SCRAPE_METADATA = {
     "model": "consumer-model",
     "model_uuid": "abcdef",
     "application": "consumer",
-    "static_scrape_port": "8000",
-    "static_scrape_path": "/metrics",
 }
+SCRAPE_JOBS = [
+    {
+        "static_configs": [
+            {
+                "targets": ["*:8000"],
+                "labels": {
+                    "status": "testing"
+                }
+            }
+        ]
+    }
+]
 
 
 class PrometheusCharm(CharmBase):
@@ -53,7 +63,7 @@ class TestProvider(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id,
             "consumer",
-            {"prometheus_scrape_metadata": json.dumps(SCRAPE_METADATA)},
+            {"scrape_metadata": json.dumps(SCRAPE_METADATA)},
         )
         self.assertEqual(self.harness.charm._stored.num_events, 1)
 
@@ -72,7 +82,10 @@ class TestProvider(unittest.TestCase):
         self.harness.update_relation_data(
             rel_id,
             "consumer",
-            {"prometheus_scrape_metadata": json.dumps(SCRAPE_METADATA)},
+            {
+                "scrape_metadata": json.dumps(SCRAPE_METADATA),
+                "scrape_jobs": json.dumps(SCRAPE_JOBS)
+            },
         )
         self.harness.add_relation_unit(rel_id, "consumer/0")
         self.harness.update_relation_data(
@@ -83,7 +96,6 @@ class TestProvider(unittest.TestCase):
         self.assertEqual(len(jobs), 1)
         job = jobs[0]
         self.assertIn("job_name", job)
-        self.assertIn("metrics_path", job)
         self.assertIn("static_configs", job)
         static_configs = job["static_configs"]
         self.assertEqual(len(static_configs), 1)

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -11,6 +11,7 @@ from charms.prometheus_k8s.v1.prometheus import PrometheusProvider
 
 SCRAPE_METADATA = {
     "model": "consumer-model",
+    "model_uuid": "abcdef",
     "application": "consumer",
     "static_scrape_port": "8000",
     "static_scrape_path": "/metrics",
@@ -93,5 +94,6 @@ class TestProvider(unittest.TestCase):
         self.assertEqual(len(targets), 1)
         labels = static_config["labels"]
         self.assertIn("juju_model", labels)
+        self.assertIn("juju_model_uuid", labels)
         self.assertIn("juju_application", labels)
         self.assertIn("juju_unit", labels)

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -15,16 +15,7 @@ SCRAPE_METADATA = {
     "application": "consumer",
 }
 SCRAPE_JOBS = [
-    {
-        "static_configs": [
-            {
-                "targets": ["*:8000"],
-                "labels": {
-                    "status": "testing"
-                }
-            }
-        ]
-    }
+    {"static_configs": [{"targets": ["*:8000"], "labels": {"status": "testing"}}]}
 ]
 
 
@@ -61,9 +52,7 @@ class TestProvider(unittest.TestCase):
 
         rel_id = self.harness.add_relation("monitoring", "consumer")
         self.harness.update_relation_data(
-            rel_id,
-            "consumer",
-            {"scrape_metadata": json.dumps(SCRAPE_METADATA)},
+            rel_id, "consumer", {"scrape_metadata": json.dumps(SCRAPE_METADATA)}
         )
         self.assertEqual(self.harness.charm._stored.num_events, 1)
 
@@ -84,7 +73,7 @@ class TestProvider(unittest.TestCase):
             "consumer",
             {
                 "scrape_metadata": json.dumps(SCRAPE_METADATA),
-                "scrape_jobs": json.dumps(SCRAPE_JOBS)
+                "scrape_jobs": json.dumps(SCRAPE_JOBS),
             },
         )
         self.harness.add_relation_unit(rel_id, "consumer/0")

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -13,7 +13,7 @@ SCRAPE_METADATA = {
     "model": "consumer-model",
     "application": "consumer",
     "static_scrape_port": "8000",
-    "static_scrape_path": "/metrics"
+    "static_scrape_path": "/metrics",
 }
 
 
@@ -49,30 +49,34 @@ class TestProvider(unittest.TestCase):
         self.assertEqual(self.harness.charm._stored.num_events, 0)
 
         rel_id = self.harness.add_relation("monitoring", "consumer")
-        self.harness.update_relation_data(rel_id, "consumer", {
-            "prometheus_scrape_metadata": json.dumps(SCRAPE_METADATA)
-        })
+        self.harness.update_relation_data(
+            rel_id,
+            "consumer",
+            {"prometheus_scrape_metadata": json.dumps(SCRAPE_METADATA)},
+        )
         self.assertEqual(self.harness.charm._stored.num_events, 1)
 
     def test_provider_notifies_on_new_scrape_target(self):
         self.assertEqual(self.harness.charm._stored.num_events, 0)
         rel_id = self.harness.add_relation("monitoring", "consumer")
         self.harness.add_relation_unit(rel_id, "consumer/0")
-        self.harness.update_relation_data(rel_id, "consumer/0", {
-            "prometheus_scrape_host": "1.1.1.1",
-        })
+        self.harness.update_relation_data(
+            rel_id, "consumer/0", {"prometheus_scrape_host": "1.1.1.1"}
+        )
         self.assertEqual(self.harness.charm._stored.num_events, 1)
 
     def test_provider_returns_static_scrape_jobs(self):
         self.assertEqual(self.harness.charm._stored.num_events, 0)
         rel_id = self.harness.add_relation("monitoring", "consumer")
-        self.harness.update_relation_data(rel_id, "consumer", {
-            "prometheus_scrape_metadata": json.dumps(SCRAPE_METADATA)
-        })
+        self.harness.update_relation_data(
+            rel_id,
+            "consumer",
+            {"prometheus_scrape_metadata": json.dumps(SCRAPE_METADATA)},
+        )
         self.harness.add_relation_unit(rel_id, "consumer/0")
-        self.harness.update_relation_data(rel_id, "consumer/0", {
-            "prometheus_scrape_host": "1.1.1.1",
-        })
+        self.harness.update_relation_data(
+            rel_id, "consumer/0", {"prometheus_scrape_host": "1.1.1.1"}
+        )
         self.assertEqual(self.harness.charm._stored.num_events, 2)
         jobs = self.harness.charm.prometheus_provider.jobs()
         self.assertEqual(len(jobs), 1)


### PR DESCRIPTION
This PR fundamentally changes the structure of the Prometheus charm library. This is a breaking change because the two methods `add_endpoint()` and `remove_endpoint()` have been removed. Instead the `PrometheusProvider` now scrapes each unit of the `PrometheusConsumer` without being told explicitly which are the scrape endpoints. However it is still possible to configure the metrics path and port for each consumer charm. Future PR's will elaborate further on this configurability. 

These changes were necessitated because of requirement to provide per unit scrape labels. In particular the requirement to provide a different unit name label for each consumer unit.