### PR TITLE
Defensively parse JSON in build_info

### DIFF
--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -30,8 +30,11 @@ class Prometheus:
         except urllib3.exceptions.MaxRetryError:
             return {}
 
-        info = json.loads(response.data.decode("utf-8"))
-        if info["status"] == "success":
-            return info["data"]
-        else:
+        try:
+            info = json.loads(response.data.decode("utf-8"))
+            if info["status"] == "success":
+                return info["data"]
+            else:
+                return {}
+        except:
             return {}

--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -27,14 +27,11 @@ class Prometheus:
 
         try:
             response = self.http.request("GET", url)
-        except urllib3.exceptions.MaxRetryError:
-            return {}
-
-        try:
             info = json.loads(response.data.decode("utf-8"))
             if info["status"] == "success":
                 return info["data"]
-            else:
-                return {}
-        except:
-            return {}
+        except Exception:
+            # Nothing worth logging, seriously
+            pass
+
+        return {}


### PR DESCRIPTION
There are situations in which Prometheus is not ready yet that will not return valid JSON (and may return actually an empty response body).

This commit adds error handling for invalid JSON in the response returned by the `api/v1/status/buildinfo` endpoint.