### PR TITLE
Fix missing brackets for alert rule file glob

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -346,7 +346,7 @@ class PrometheusCharm(CharmBase):
 
         scrape_config = {
             "global": self._prometheus_global_config(),
-            "rule_files": os.path.join(RULES_DIR, "juju_*.rules"),
+            "rule_files": [os.path.join(RULES_DIR, "juju_*.rules")],
             "scrape_configs": [],
         }
 


### PR DESCRIPTION
This commit fixes a typo that crept in during review changes for
the last PR. In changing the file path glob for alert rule files
to use os.path.join the enclosing brackets were acidentally removed.