### PR TITLE
Enable forwarding of scrape jobs through proxy charms

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus.py
@@ -689,12 +689,14 @@ class PrometheusProvider(ProviderBase):
             topology information with the exception of unit name.
         """
         juju_labels = labels.copy()  # deep copy not needed
-        with_topology = not JUJU_TOPOLOGY_LABEL_SET.isdisjoint(labels.keys())
 
-        if not with_topology:
-            juju_labels["juju_model"] = scrape_metadata["model"]
-            juju_labels["juju_model_uuid"] = scrape_metadata["model_uuid"]
-            juju_labels["juju_application"] = scrape_metadata["application"]
+        juju_labels.update(
+            {
+                "juju_model": scrape_metadata["model"],
+                "juju_model_uuid": scrape_metadata["model_uuid"],
+                "juju_application": scrape_metadata["application"],
+            }
+        )
 
         return juju_labels
 
@@ -759,7 +761,10 @@ class PrometheusProvider(ProviderBase):
             A dictionary containing the static scrape configuration
             for a single wildcard host.
         """
-        juju_labels = self._set_juju_labels(labels, scrape_metadata)
+        with_topology = not JUJU_TOPOLOGY_LABEL_SET.isdisjoint(labels.keys())
+
+        if not with_topology:
+            juju_labels = self._set_juju_labels(labels, scrape_metadata)
 
         if "juju_unit" not in juju_labels:
             # '/' is not allowed in Prometheus label names. It technically works,

--- a/lib/charms/prometheus_k8s/v0/prometheus.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus.py
@@ -616,9 +616,12 @@ class PrometheusProvider(ProviderBase):
                         )
                     )
 
+        return self._to_job_config(job_name, job["metrics_path"], static_configs)
+
+    def _to_job_config(self, job_name, metrics_path, static_configs):
         return {
             "job_name": job_name,
-            "metrics_path": job["metrics_path"],
+            "metrics_path": metrics_path,
             "relabel_configs": [
                 # This relabelling rule will match metrics that do not have the full Juju topology,
                 # and ensure that metrics without a juju_unit are still unique per instance
@@ -648,8 +651,6 @@ class PrometheusProvider(ProviderBase):
             ],
             "static_configs": static_configs,
         }
-
-
 
     def _is_aggregated_static_config(self, static_config, scrape_metadata):
         # Charms that forward scrape jobs on behalf of other charms

--- a/lib/charms/prometheus_k8s/v0/prometheus.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus.py
@@ -97,6 +97,7 @@ structure as the value of `jobs`.
 The wildcard ("*") host specification implies that the scrape targets
 will automatically be set to the host addresses advertised by each
 unit of the consumer charm.
+Whitespaces around the "*" character are not supported.
 
 It is also possible to change the metrics path and scrape multiple
 ports, for example
@@ -647,6 +648,8 @@ class PrometheusProvider(ProviderBase):
             ],
             "static_configs": static_configs,
         }
+
+
 
     def _is_aggregated_static_config(self, static_config, scrape_metadata):
         # Charms that forward scrape jobs on behalf of other charms

--- a/lib/charms/prometheus_k8s/v0/prometheus.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus.py
@@ -689,8 +689,9 @@ class PrometheusProvider(ProviderBase):
             topology information with the exception of unit name.
         """
         juju_labels = labels.copy()  # deep copy not needed
+        with_topology = not JUJU_TOPOLOGY_LABEL_SET.isdisjoint(labels.keys())
 
-        if JUJU_TOPOLOGY_LABEL_SET.isdisjoint(juju_labels.keys()):
+        if not with_topology:
             juju_labels["juju_model"] = scrape_metadata["model"]
             juju_labels["juju_model_uuid"] = scrape_metadata["model_uuid"]
             juju_labels["juju_application"] = scrape_metadata["application"]
@@ -717,7 +718,9 @@ class PrometheusProvider(ProviderBase):
             A dictionary containing the static scrape configuration
             for a list of fully qualified hosts.
         """
-        if not JUJU_TOPOLOGY_LABEL_SET.isdisjoint(labels.keys()):
+        with_topology = not JUJU_TOPOLOGY_LABEL_SET.isdisjoint(labels.keys())
+
+        if with_topology:
             logger.debug(
                 "Some Juju topology labels already found in the provided labels: "
                 f"{labels}; will not set any Juju topology label based on the "

--- a/src/charm.py
+++ b/src/charm.py
@@ -409,6 +409,7 @@ class PrometheusCharm(CharmBase):
         info = prometheus.build_info()
         if info:
             return info.get("version", None)
+        self.unit.status = MaintenanceStatus("Prometheus provider is not yet ready.")
         return None
 
     @property

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -230,14 +230,8 @@ class TestProvider(unittest.TestCase):
                 self.assertIn("juju_model_uuid", labels)
                 self.assertIn("juju_application", labels)
 
-            # relabel_configs = job["relabel_configs"]
-            # self.assertEqual(len(relabel_configs), 1)
-
-            # relabel_config = relabel_configs[0]
-            # self.assertEqual(
-            #     relabel_config.get("source_labels"),
-            #     ["juju_model", "juju_model_uuid", "juju_application", "juju_unit"],
-            # )
+            relabel_configs = job["relabel_configs"]
+            self.assertEqual(len(relabel_configs), 2)
 
     def test_provider_notifies_on_new_scrape_relation(self):
         self.assertEqual(self.harness.charm._stored.num_events, 0)


### PR DESCRIPTION
The `prometheus_scrape` relation works remarkably differently from the `http` relation used in the Prometheus machine charm. We considered several options to achieve interoperability without having to modify existing machine charms. One that was promising was to implement the machine-charm relations in the Prometheus Operator charm, but we found out that we cannot correctly create the Juju topology, because the remote [model name and uuid are not available over cross-model relations](https://chat.charmhub.io/charmhub/pl/wois69md6tfnprf3cagta7bjch).

So, we went for The [LMAProxyOperator charm](https://github.com/mmanciop/lma-proxy-operator): a "proxy" machine charm that is meant to be deployed in the same model as the machine charms to be scraped by Prometheus, and that will translate between the machine-charm Prometheus relations and `prometheus_scrape`.

Since this use-case is somewhat of a corner-case for the Prometheus charm library, it is not worth it to provide a first-level support like allowing the charm using `PrometheusConsumer` to specify custom `scrape_metadata` or the like.

However, there are a few corner cases to adjust:
1. Prometheus must not override the Juju topology labels in a `static_config` if they are present. One of the things that the LMAProxyOperator charm is supposed to do, is to _fill in the Juju topology_, since it is the only charm that (1) understands how `prometheus_scrape` works and (2) has access to the model name and uuid (since it is deployed into that model)
2. The Prometheus operator should not generate a `target` for the charm that is _forwarding_ scrape jobs; that is, `LMAProxyOperator` should have no target of its own, although it is related with Prometheus over a `prometheus_scrape`. THis case can be detected by comparing the Juju topology labels in the `static_config` against the `scrape_metadata` and, if differences in values are detected, do not add additional targets.