### PR TITLE
Implement reload of configurations rather than Prometheus restart

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@ coverage
 flake8
 pytest
 pytest-cov
+responses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 git+git://github.com/canonical/operator
 pyaml
 requests
-deepdiff

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 git+git://github.com/canonical/operator
 pyaml
-urllib3
+requests
+deepdiff

--- a/src/charm.py
+++ b/src/charm.py
@@ -108,7 +108,7 @@ class PrometheusCharm(CharmBase):
         # If the startup arguments are the same and we use the
         # we lifecycle, sent the config reload HTTP request instead
 
-        services_changed = not DeepDiff(
+        services_changed = DeepDiff(
             current_layer.get("services", {}),
             new_layer.get("services", {}),
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -33,7 +33,9 @@ class PrometheusCharm(CharmBase):
 
         super().__init__(*args)
 
-        self._prometheus_server = Prometheus("localhost", str(self.model.config["port"]))
+        self._prometheus_server = Prometheus(
+            "localhost", str(self.model.config["port"])
+        )
 
         self._stored.set_default(provider_ready=False)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -35,7 +35,7 @@ class PrometheusCharm(CharmBase):
 
         super().__init__(*args)
 
-        self._prometheus = Prometheus("localhost", str(self.model.config["port"]))
+        self._prometheus_api = Prometheus("localhost", str(self.model.config["port"]))
 
         self._stored.set_default(provider_ready=False)
 
@@ -115,7 +115,7 @@ class PrometheusCharm(CharmBase):
         )
 
         if not prometheus_service_changed:
-            self._prometheus.reload_configuration()
+            self._prometheus_api.reload_configuration()
             logger.info("Configuration reloaded")
         else:
             container.add_layer("prometheus", new_layer, combine=True)
@@ -428,7 +428,7 @@ class PrometheusCharm(CharmBase):
             a string consisting of the Prometheus version information or
             None if Prometheus server is not reachable.
         """
-        info = self._prometheus.build_info()
+        info = self._prometheus_api.build_info()
         if info:
             return info.get("version", None)
         return None

--- a/src/charm.py
+++ b/src/charm.py
@@ -107,7 +107,7 @@ class PrometheusCharm(CharmBase):
         new_layer = self._prometheus_layer()
 
         # If the startup arguments are the same and we use the
-        # we lifecycle, sent the config reload HTTP request instead
+        # web lifecycle, sent the config reload HTTP request instead
 
         prometheus_service_changed = not current_services.get("prometheus") or DeepDiff(
             current_services.get("prometheus").to_dict(),

--- a/src/charm.py
+++ b/src/charm.py
@@ -33,7 +33,7 @@ class PrometheusCharm(CharmBase):
 
         super().__init__(*args)
 
-        self._prometheus_api = Prometheus("localhost", str(self.model.config["port"]))
+        self._prometheus_server = Prometheus("localhost", str(self.model.config["port"]))
 
         self._stored.set_default(provider_ready=False)
 
@@ -119,7 +119,7 @@ class PrometheusCharm(CharmBase):
         )
 
         if not prometheus_service_changed:
-            self._prometheus_api.reload_configuration()
+            self._prometheus_server.reload_configuration()
             logger.info("Configuration reloaded")
         else:
             container.add_layer("prometheus", new_layer, combine=True)
@@ -432,7 +432,7 @@ class PrometheusCharm(CharmBase):
             a string consisting of the Prometheus version information or
             None if Prometheus server is not reachable.
         """
-        info = self._prometheus_api.build_info()
+        info = self._prometheus_server.build_info()
         if info:
             return info.get("version", None)
         return None

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,8 +7,6 @@ import logging
 import yaml
 import json
 
-from deepdiff import DeepDiff
-
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.main import main
@@ -109,9 +107,15 @@ class PrometheusCharm(CharmBase):
         # If the startup arguments are the same and we use the
         # web lifecycle, sent the config reload HTTP request instead
 
-        prometheus_service_changed = "prometheus" not in current_services or DeepDiff(
-            current_services.get("prometheus").to_dict(),
-            new_layer.get("services", {}).get("prometheus", {}),
+        current_prometheus_service = (
+            current_services.get("prometheus").to_dict()
+            if "prometheus" in current_services
+            else {}
+        )
+        new_prometheus_service = new_layer.get("services", {}).get("prometheus", {})
+
+        prometheus_service_changed = (
+            current_prometheus_service != new_prometheus_service
         )
 
         if not prometheus_service_changed:

--- a/src/charm.py
+++ b/src/charm.py
@@ -109,7 +109,7 @@ class PrometheusCharm(CharmBase):
         # If the startup arguments are the same and we use the
         # web lifecycle, sent the config reload HTTP request instead
 
-        prometheus_service_changed = not current_services.get("prometheus") or DeepDiff(
+        prometheus_service_changed = "prometheus" not in current_services or DeepDiff(
             current_services.get("prometheus").to_dict(),
             new_layer.get("services", {}).get("prometheus", {}),
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -115,7 +115,7 @@ class PrometheusCharm(CharmBase):
         )
 
         if not prometheus_service_changed:
-            self._prometheus.trigger_configuration_reload()
+            self._prometheus.reload_configuration()
             logger.info("Configuration reloaded")
         else:
             container.add_layer("prometheus", new_layer, combine=True)

--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -26,7 +26,6 @@ class Prometheus:
             response = post(url, timeout=self.api_timeout)
 
             if response.status_code == 200:
-                logger.debug("Configuration reloaded")
                 return True
         except (ConnectionError, ConnectTimeout) as e:
             logger.debug("config reload error via %s: %s", url, str(e))

--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -1,7 +1,6 @@
 import logging
 from requests import get, post
 from requests.exceptions import ConnectionError, ConnectTimeout
-from typing import Dict, Union
 
 logger = logging.getLogger(__name__)
 

--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -15,7 +15,7 @@ class Prometheus:
         self.base_url = "http://{}:{}".format(host, port)
         self.api_timeout = api_timeout
 
-    def trigger_configuration_reload(self):
+    def reload_configuration(self):
         """Send a POST request to to hot-reload the config.
         This reduces down-time compared to restarting the service.
         Returns:

--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -1,7 +1,7 @@
 import logging
 from requests import get, post
 from requests.exceptions import ConnectionError, ConnectTimeout
-from typing import Dict
+from typing import Dict, Union
 
 logger = logging.getLogger(__name__)
 

--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -1,6 +1,7 @@
 import logging
 from requests import get, post
 from requests.exceptions import ConnectionError, ConnectTimeout
+from typing import Dict
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ class Prometheus:
 
         return False
 
-    def build_info(self) -> dict:
+    def build_info(self) -> Dict[str, Union[str, dict]]:
         """Fetch build information from Prometheus.
 
         Returns:

--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -33,7 +33,7 @@ class Prometheus:
 
         return False
 
-    def build_info(self) -> Dict[str, Union[str, dict]]:
+    def build_info(self):
         """Fetch build information from Prometheus.
 
         Returns:

--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 
 class Prometheus:
-    def __init__(self, host, port, api_timeout=2.0):
+    def __init__(self, host: str, port: int, api_timeout=2.0):
         """Utility to manage a Prometheus application.
         Args:
             host: host address of Prometheus application.
@@ -15,7 +15,7 @@ class Prometheus:
         self.base_url = "http://{}:{}".format(host, port)
         self.api_timeout = api_timeout
 
-    def reload_configuration(self):
+    def reload_configuration(self) -> bool:
         """Send a POST request to to hot-reload the config.
         This reduces down-time compared to restarting the service.
         Returns:
@@ -32,7 +32,7 @@ class Prometheus:
 
         return False
 
-    def build_info(self):
+    def build_info(self) -> dict:
         """Fetch build information from Prometheus.
 
         Returns:

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -205,6 +205,22 @@ class TestCharm(unittest.TestCase):
         prometheus_scrape_config = scrape_config(config, "prometheus")
         self.assertIsNotNone(prometheus_scrape_config, "No default config found")
 
+    @patch("prometheus_server.Prometheus.trigger_configuration_reload")
+    @patch("ops.testing._TestingPebbleClient.push")
+    def test_configuration_reload(self, push, trigger_configuration_reload):
+        self.harness.update_config(MINIMAL_CONFIG)
+
+        push.assert_called()
+        trigger_configuration_reload.assert_not_called()
+
+        label_config = MINIMAL_CONFIG.copy()
+        labels = {"name1": "value1", "name2": "value2"}
+        label_config["external-labels"] = json.dumps(labels)
+
+        self.harness.update_config(label_config)
+
+        trigger_configuration_reload.assert_called()
+
 
 def alerting_config(config):
     config_yaml = config[1]

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -205,7 +205,7 @@ class TestCharm(unittest.TestCase):
         prometheus_scrape_config = scrape_config(config, "prometheus")
         self.assertIsNotNone(prometheus_scrape_config, "No default config found")
 
-    @patch("prometheus_server.Prometheus.trigger_configuration_reload")
+    @patch("prometheus_server.Prometheus.reload_configuration")
     @patch("ops.testing._TestingPebbleClient.push")
     def test_configuration_reload(self, push, trigger_configuration_reload):
         self.harness.update_config(MINIMAL_CONFIG)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -37,7 +37,7 @@ class TestServer(unittest.TestCase):
             status=200,
         )
 
-        self.assertTrue(self.prometheus.trigger_configuration_reload())
+        self.assertTrue(self.prometheus.reload_configuration())
 
     @responses.activate
     def test_prometheus_server_reload_configuration_failure(self):
@@ -47,4 +47,4 @@ class TestServer(unittest.TestCase):
             status=500,
         )
 
-        self.assertFalse(self.prometheus.trigger_configuration_reload())
+        self.assertFalse(self.prometheus.reload_configuration())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,10 +1,8 @@
 # Copyright 2020 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import json
+import responses
 import unittest
-
-from unittest.mock import patch
 
 from prometheus_server import Prometheus
 
@@ -13,14 +11,40 @@ class TestServer(unittest.TestCase):
     def setUp(self):
         self.prometheus = Prometheus("localhost", "9090")
 
-    @patch("urllib3.PoolManager.request")
-    def test_prometheus_server_returns_valid_data(self, request):
+    @responses.activate
+    def test_prometheus_server_returns_valid_data(self):
         version = "1.0.0"
-        request.return_value.data = bytes(
-            json.dumps({"status": "success", "data": {"version": version}}),
-            encoding="utf-8",
+
+        responses.add(
+            responses.GET,
+            "http://localhost:9090/api/v1/status/buildinfo",
+            json={
+                "status": "success",
+                "data": {"version": version},
+            },
+            status=200,
         )
+
         build_info = self.prometheus.build_info()
         got_version = build_info.get("version", None)
-        self.assertIsNotNone(got_version)
         self.assertEqual(got_version, version)
+
+    @responses.activate
+    def test_prometheus_server_reload_configuration_success(self):
+        responses.add(
+            responses.POST,
+            "http://localhost:9090/-/reload",
+            status=200,
+        )
+
+        self.assertTrue(self.prometheus.trigger_configuration_reload())
+
+    @responses.activate
+    def test_prometheus_server_reload_configuration_failure(self):
+        responses.add(
+            responses.POST,
+            "http://localhost:9090/-/reload",
+            status=500,
+        )
+
+        self.assertFalse(self.prometheus.trigger_configuration_reload())

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 deps = 
     pytest
     coverage
-    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/requirements-dev.txt
 commands =
     coverage run --branch --source={toxinidir}/src,{toxinidir}/lib/charms/prometheus_k8s -m pytest -v --tb native {posargs} {toxinidir}/tests 
     coverage report -m


### PR DESCRIPTION
In case the configuration of Prometheus changes, but not its startup command, there is no reason to restart the process: we already activate the Web API to trigger the hot reload of configurations from file, and this commit adds support for it in `PrometheusServer`, and its triggering when we detect and configuration reload that would create the same layer as the existing one in terms of startup commands.

Closes #36