### PR TITLE
Correct external_url path

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -236,10 +236,9 @@ class PrometheusCharm(CharmBase):
         ]
 
         if self.model.get_relation("ingress"):
-            path = self.app.name  # Same as "service-name" in the ingress relation
 
             # TODO The ingress should communicate the externally-visible scheme
-            external_url = f"http://{self._external_hostname}:{self.port}/{path}"
+            external_url = f"http://{self._external_hostname}:{self.port}"
 
             args.append(f"--web.external-url={external_url}")
 

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -90,7 +90,7 @@ class TestCharm(unittest.TestCase):
         plan = self.harness.get_container_pebble_plan("prometheus")
         self.assertEqual(
             cli_arg(plan, "--web.external-url"),
-            "http://prometheus-k8s:9090/prometheus-k8s",
+            "http://prometheus-k8s:9090",
         )
 
     @patch("ops.testing._TestingPebbleClient.push")


### PR DESCRIPTION
The command line switch for web.external-url needs to be set without the application name in the path.