### PR TITLE
Patch K8s service to list port 9090

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 git+git://github.com/canonical/operator
+kubernetes
 pyaml
 requests

--- a/src/charm.py
+++ b/src/charm.py
@@ -487,7 +487,7 @@ class PrometheusCharm(CharmBase):
         # hostname will correspond to the deployed application name in the
         # model, but allow it to be set to something specific via config.
 
-        return self.config["web-external-url"] or f"{self.app.name}.juju"
+        return self.config["web-external-url"] or f"{self.app.name}"
 
     @property
     def port(self):

--- a/src/kubernetes_service.py
+++ b/src/kubernetes_service.py
@@ -1,0 +1,122 @@
+import kubernetes
+from typing import List, Tuple
+
+
+class PatchFailed(RuntimeError):
+    """Patching the kubernetes service failed."""
+
+
+class K8sServicePatch:
+    """A utility for patching the Kubernetes service set up by Juju.
+
+    Attributes:
+            namespace_file (str): path to the k8s namespace file in the charm container
+    """
+
+    namespace_file = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+    @staticmethod
+    def namespace() -> str:
+        """Read the Kubernetes namespace we're deployed in from the mounted service token
+
+        Returns:
+            str: The current Kubernetes namespace
+        """
+        with open(K8sServicePatch.namespace_file, "r") as f:
+            return f.read().strip()
+
+    @staticmethod
+    def _k8s_auth():
+        """Authenticate with the Kubernetes API using an in-cluster service token
+
+        Raises:
+            PatchFailed: if no permissions to read cluster role
+        """
+        # Authenticate against the Kubernetes API using a mounted ServiceAccount token
+        kubernetes.config.load_incluster_config()
+        # Test the service account we've got for sufficient perms
+        api = kubernetes.client.CoreV1Api(kubernetes.client.ApiClient())
+
+        try:
+            api.list_namespaced_service(namespace=K8sServicePatch.namespace())
+        except kubernetes.client.exceptions.ApiException as e:
+            if e.status == 403:
+                raise PatchFailed(
+                    "No permission to read cluster role. " "Run `juju trust` on this application."
+                ) from e
+            else:
+                raise e
+
+    @staticmethod
+    def _k8s_service(
+        app: str, service_ports: List[Tuple[str, int, int]]
+    ) -> kubernetes.client.V1Service:
+        """Property accessor to return a valid Kubernetes Service representation for Alertmanager
+
+        Args:
+            app: app name
+            service_ports: a list of tuples (name, port, target_port) for every service port.
+
+        Returns:
+            kubernetes.client.V1Service: A Kubernetes Service with correctly annotated metadata and ports
+        """
+
+        ports = [
+            kubernetes.client.V1ServicePort(name=port[0], port=port[1], target_port=port[2])
+            for port in service_ports
+        ]
+
+        ns = K8sServicePatch.namespace()
+        return kubernetes.client.V1Service(
+            api_version="v1",
+            metadata=kubernetes.client.V1ObjectMeta(
+                namespace=ns,
+                name=app,
+                labels={"app.kubernetes.io/name": app},
+            ),
+            spec=kubernetes.client.V1ServiceSpec(
+                ports=ports,
+                selector={"app.kubernetes.io/name": app},
+            ),
+        )
+
+    @staticmethod
+    def set_ports(app: str, service_ports: List[Tuple[str, int, int]]):
+        """Patch the Kubernetes service created by Juju to map the correct port
+
+        Currently, Juju uses port 65535 for all endpoints. This can be observed via:
+
+            kubectl describe services -n <model_name> | grep Port -C 2
+
+        At runtime, pebble watches which ports are bound and we need to patch the gap for pebble not telling Juju to fix
+        the K8S Service definition.
+
+        Typical usage example from within charm code (e.g. on_install):
+
+            service_ports = [("my-app-api", 9093, 9093), ("my-app-ha", 9094, 9094)]
+            K8sServicePatch.set_ports(self.app.name, service_ports)
+
+        Args:
+            app: app name
+            service_ports: a list of tuples (name, port, target_port) for every service port.
+
+        Raises:
+            PatchFailed: if patching fails.
+        """
+        # First ensure we're authenticated with the Kubernetes API
+        K8sServicePatch._k8s_auth()
+
+        ns = K8sServicePatch.namespace()
+        # Set up a Kubernetes client
+        api = kubernetes.client.CoreV1Api(kubernetes.client.ApiClient())
+        try:
+            # Delete the existing service so we can redefine with correct ports
+            # I don't think you can issue a patch that *replaces* the existing ports,
+            # only append
+            api.delete_namespaced_service(name=app, namespace=ns)
+            # Recreate the service with the correct ports for the application
+            api.create_namespaced_service(
+                namespace=ns, body=K8sServicePatch._k8s_service(app, service_ports)
+            )
+        except kubernetes.client.exceptions.ApiException as e:
+            raise PatchFailed("Failed to patch k8s service: {}".format(e))

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -90,7 +90,7 @@ class TestCharm(unittest.TestCase):
         plan = self.harness.get_container_pebble_plan("prometheus")
         self.assertEqual(
             cli_arg(plan, "--web.external-url"),
-            "http://prometheus-k8s.juju:9090/prometheus-k8s",
+            "http://prometheus-k8s:9090/prometheus-k8s",
         )
 
     @patch("ops.testing._TestingPebbleClient.push")

--- a/tests/test_kubernetes_service.py
+++ b/tests/test_kubernetes_service.py
@@ -1,0 +1,76 @@
+import unittest
+from unittest.mock import patch
+
+import kubernetes
+from kubernetes_service import K8sServicePatch, PatchFailed
+
+
+class TestK8sServicePatch(unittest.TestCase):
+    def setUp(self) -> None:
+        self.service_ports = [
+            ("svc1", 1234, 12340),
+            ("svc2", 1235, 12350),
+        ]
+
+    @patch("charm.K8sServicePatch.namespace", lambda: "lma")
+    def test_k8s_service(self):
+        app_name = "some-app"
+        service = K8sServicePatch._k8s_service(app_name, self.service_ports)
+
+        self.assertEqual(service.metadata.name, app_name)
+        self.assertEqual(service.metadata.namespace, "lma")
+        self.assertEqual(service.metadata.labels, {"app.kubernetes.io/name": app_name})
+        self.assertEqual(
+            service.spec.ports,
+            [
+                kubernetes.client.V1ServicePort(
+                    name="svc1",
+                    port=1234,
+                    target_port=12340,
+                ),
+                kubernetes.client.V1ServicePort(
+                    name="svc2",
+                    port=1235,
+                    target_port=12350,
+                ),
+            ],
+        )
+
+    @patch("kubernetes_service.K8sServicePatch.namespace")
+    @patch("kubernetes_service.K8sServicePatch._k8s_auth")
+    @patch("kubernetes_service.kubernetes.client.CoreV1Api.delete_namespaced_service")
+    @patch("kubernetes_service.kubernetes.client.CoreV1Api.create_namespaced_service")
+    def test_patch_k8s_service(self, create, delete, auth, ns):
+        ns.return_value = "lma"
+        name = "some-app"
+        create.return_value = delete.return_value = auth.return_value = True
+        K8sServicePatch.set_ports(name, self.service_ports)
+        delete.assert_called_with(name=name, namespace=K8sServicePatch.namespace())
+        create.assert_called_with(
+            namespace=K8sServicePatch.namespace(),
+            body=K8sServicePatch._k8s_service(name, self.service_ports),
+        )
+
+        # Now test when we don't get authed
+        auth.side_effect = PatchFailed("Dummy exception")
+        self.assertRaises(PatchFailed, K8sServicePatch.set_ports, name, self.service_ports)
+        # Ensure these mock calls haven't increased from the last run
+        delete.assert_called_with(name=name, namespace=K8sServicePatch.namespace())
+        create.assert_called_with(
+            namespace=K8sServicePatch.namespace(),
+            body=K8sServicePatch._k8s_service(name, self.service_ports),
+        )
+
+    @patch("kubernetes_service.kubernetes.client.CoreV1Api.list_namespaced_service")
+    @patch("kubernetes_service.K8sServicePatch.namespace")
+    @patch("kubernetes_service.kubernetes.config.load_incluster_config")
+    def test_k8s_auth(self, load_config, ns, list_svc):
+        ns.return_value = "lma"
+        load_config.return_value = True
+
+        K8sServicePatch._k8s_auth()
+        list_svc.assert_called_with(namespace=K8sServicePatch.namespace())
+
+        # Now test what happens when listing a svc throws an exception
+        list_svc.side_effect = kubernetes.client.exceptions.ApiException(status=403)
+        self.assertRaises(PatchFailed, K8sServicePatch._k8s_auth)


### PR DESCRIPTION
Hook into the charm's `install` and `upgrade_charm` hooks the patching of the K8s service, so that we get the following awesomeness:

```
michele@boombox:~/git/prometheus-operator$ microk8s.kubectl get services -n prometheus-test
NAME                   TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)     AGE
modeloperator          ClusterIP   10.152.183.212   <none>        17071/TCP   18m
prometheus-endpoints   ClusterIP   None             <none>        <none>      13m
prometheus             ClusterIP   10.152.183.88    <none>        9090/TCP    77s
```