### PR TITLE
Improve structure and documentation of *.rule files

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus.py
@@ -231,21 +231,21 @@ related `MetricsEndpointProvider` charms and enabling corresponding alerts withi
 Prometheus charm.  Alert rules are automatically gathered by `MetricsEndpointProvider`
 charms when using this library, from a directory conventionally named
 `prometheus_alert_rules`. This directory must reside at the top level
-in the `src` folder of the provider charm. Each file in this directory
-is assumed to be a single alert rule in YAML format. The format of this
-alert rule conforms to [Prometheus
-documentation](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
+in the `src` folder of the consumer charm. Each file in this directory
+is assumed to be a single alert rule in YAML format. The file name must
+have the `.rule` extension. The format of this alert rule conforms to the
+[Prometheus documentation](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
 An example of the contents of one such file is shown below.
 
 ```
-- alert: HighRequestLatency
-  expr: job:request_latency_seconds:mean5m{my_key=my_value, %%juju_topology%%} > 0.5
-  for: 10m
-  labels:
-    severity: Medium
-    type: HighLatency
-  annotations:
-    summary: High request latency for {{ $labels.instance }}.
+alert: HighRequestLatency
+expr: job:request_latency_seconds:mean5m{my_key=my_value, %%juju_topology%%} > 0.5
+for: 10m
+labels:
+  severity: Medium
+  type: HighLatency
+annotations:
+  summary: High request latency for {{ $labels.instance }}.
 ```
 
 It is **very important** to note the `%%juju_topology%%` filter in the
@@ -840,8 +840,7 @@ class MetricsEndpointProvider(ProviderBase):
             with path.open() as rule_file:
                 # Load a list of rules from file then add labels and filters
                 try:
-                    rules = yaml.safe_load(rule_file)
-                    rule = rules[0]  # each file is list of one rule
+                    rule = yaml.safe_load(rule_file)
                     rule = self._label_alert_topology(rule)
                     rule = self._label_alert_expression(rule)
                     alerts.append(rule)

--- a/src/charm.py
+++ b/src/charm.py
@@ -188,23 +188,20 @@ class PrometheusCharm(CharmBase):
 
             container.remove_path(RULES_DIR, recursive=True)
 
-            alert_rules_by_rel_id = self.prometheus_provider.alerts()
+            for rel_id, alert_rules in self.prometheus_provider.alerts().items():
+                filename = "juju_{}_{}_{}_rel_{}_alert.rules".format(
+                    alert_rules["model"],
+                    alert_rules["model_uuid"],
+                    alert_rules["application"],
+                    rel_id,
+                )
 
-            if alert_rules_by_rel_id:
-                for rel_id, alert_rules in alert_rules_by_rel_id.items():
-                    filename = "juju_{}_{}_{}_rel_{}_alert.rules".format(
-                        alert_rules["model"],
-                        alert_rules["model_uuid"],
-                        alert_rules["application"],
-                        rel_id,
-                    )
+                path = os.path.join(RULES_DIR, filename)
+                rules = yaml.dump({"groups": alert_rules["groups"]})
+                logger.debug("Rules for relation %s : %s", rel_id, rules)
 
-                    path = os.path.join(RULES_DIR, filename)
-                    rules = yaml.dump({"groups": alert_rules["groups"]})
-                    logger.debug("Rules for relation %s : %s", rel_id, rules)
-
-                    container.push(path, rules, make_dirs=True)
-                    logger.debug("Pushed new alert rules '%s': %s", filename, rules)
+                container.push(path, rules, make_dirs=True)
+                logger.debug("Pushed new alert rules '%s': %s", filename, rules)
 
             self._prometheus_server.reload_configuration()
             logger.info("Updated alert rules")

--- a/src/charm.py
+++ b/src/charm.py
@@ -183,24 +183,24 @@ class PrometheusCharm(CharmBase):
             logger.debug("Abort processing alert rules: prometheus not ready")
             return
 
-        logger.debug("Processing alert rules")
+        with container.is_ready():
+            logger.debug("Processing alert rules")
 
-        container.remove_path(RULES_DIR, recursive=True)
+            container.remove_path(RULES_DIR, recursive=True)
 
-        alert_rules_by_rel_id = self.prometheus_provider.alerts()
+            alert_rules_by_rel_id = self.prometheus_provider.alerts()
 
-        if alert_rules_by_rel_id:
-            for rel_id, alert_rules in alert_rules_by_rel_id.items():
-                filename = "juju_{}_{}_{}_rel_{}_alert.rules".format(
-                    alert_rules["model"],
-                    alert_rules["model_uuid"],
-                    alert_rules["application"],
-                    rel_id,
-                )
+            if alert_rules_by_rel_id:
+                for rel_id, alert_rules in alert_rules_by_rel_id.items():
+                    filename = "juju_{}_{}_{}_rel_{}_alert.rules".format(
+                        alert_rules["model"],
+                        alert_rules["model_uuid"],
+                        alert_rules["application"],
+                        rel_id,
+                    )
 
-                with container.is_ready():
                     path = os.path.join(RULES_DIR, filename)
-                    rules = yaml.dump({"groups": alerts["groups"]})
+                    rules = yaml.dump({"groups": alert_rules["groups"]})
                     logger.debug("Rules for relation %s : %s", rel_id, rules)
 
                     container.push(path, rules, make_dirs=True)

--- a/tests/bad_alert_expressions/missing_expr.rule
+++ b/tests/bad_alert_expressions/missing_expr.rule
@@ -1,7 +1,7 @@
-- alert: PrometheusTargetMissing
-  for: 0m
-  labels:
-    severity: critical
-  annotations:
-    summary: Prometheus target missing (instance {{ $labels.instance }})
-    description: "A Prometheus target has disappeared. An exporter might be crashed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+alert: PrometheusTargetMissing
+for: 0m
+labels:
+  severity: critical
+annotations:
+  summary: Prometheus target missing (instance {{ $labels.instance }})
+  description: "A Prometheus target has disappeared. An exporter might be crashed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/tests/prometheus_alert_rules/cpu_overuse.rule
+++ b/tests/prometheus_alert_rules/cpu_overuse.rule
@@ -1,8 +1,8 @@
-- alert: CPUOverUse
-  expr: process_cpu_seconds_total{%%juju_topology%%} > 0.12
-  for: 0m
-  labels:
-    severity: Low
-  annotations:
-    summary: "Instance {{ $labels.instance }} CPU over use"
-    description: "{{ $labels.instance }} of job {{ $labels.job }} has used too much CPU."
+alert: CPUOverUse
+expr: process_cpu_seconds_total{%%juju_topology%%} > 0.12
+for: 0m
+labels:
+  severity: Low
+annotations:
+  summary: "Instance {{ $labels.instance }} CPU over use"
+  description: "{{ $labels.instance }} of job {{ $labels.job }} has used too much CPU."

--- a/tests/prometheus_alert_rules/target_missing.rule
+++ b/tests/prometheus_alert_rules/target_missing.rule
@@ -1,8 +1,8 @@
-- alert: PrometheusTargetMissing
-  expr: up{%%juju_topology%%} == 0
-  for: 0m
-  labels:
-    severity: critical
-  annotations:
-    summary: Prometheus target missing (instance {{ $labels.instance }})
-    description: "A Prometheus target has disappeared. An exporter might be crashed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+alert: PrometheusTargetMissing
+expr: up{%%juju_topology%%} == 0
+for: 0m
+labels:
+  severity: critical
+annotations:
+  summary: Prometheus target missing (instance {{ $labels.instance }})
+  description: "A Prometheus target has disappeared. An exporter might be crashed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"


### PR DESCRIPTION
Instead of expecting singleton rules in a `*.rule` file, simply expect the alert_rule object.

Also, add more logging for alert rules and ensure that the reload of alert_rules is triggered on alert reload.

(Pending: Avoid unnecessary rule reloads)

Closes #103