### PR TITLE
Fix incorrect consumer name and silent test

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -188,7 +188,7 @@ class PrometheusCharm(CharmBase):
 
             container.remove_path(RULES_DIR, recursive=True)
 
-            for rel_id, alert_rules in self.prometheus_provider.alerts().items():
+            for rel_id, alert_rules in self.metrics_consumer.alerts().items():
                 filename = "juju_{}_{}_{}_rel_{}_alert.rules".format(
                     alert_rules["model"],
                     alert_rules["model_uuid"],

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -22,9 +22,10 @@ class TestCharm(unittest.TestCase):
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 
+    @patch("ops.testing._TestingPebbleClient.remove_path")
     @patch("ops.testing._TestingPebbleClient.push")
     @patch("ops.testing._TestingModelBackend.network_get")
-    def test_grafana_is_provided_port_and_source(self, mock_net_get, _):
+    def test_grafana_is_provided_port_and_source(self, mock_net_get, *unused):
         self.harness.update_config(MINIMAL_CONFIG)
         IP = "1.1.1.1"
         net_info = {"bind-addresses": [{"interface-name": "ens1", "addresses": [{"value": IP}]}]}
@@ -37,14 +38,16 @@ class TestCharm(unittest.TestCase):
         ]
         self.assertEqual(grafana_host, "{}:{}".format(IP, "9090"))
 
+    @patch("ops.testing._TestingPebbleClient.remove_path")
     @patch("ops.testing._TestingPebbleClient.push")
-    def test_default_cli_log_level_is_info(self, _):
+    def test_default_cli_log_level_is_info(self, *unused):
         self.harness.update_config(MINIMAL_CONFIG)
         plan = self.harness.get_container_pebble_plan("prometheus")
         self.assertEqual(cli_arg(plan, "--log.level"), "info")
 
+    @patch("ops.testing._TestingPebbleClient.remove_path")
     @patch("ops.testing._TestingPebbleClient.push")
-    def test_invalid_log_level_defaults_to_debug(self, _):
+    def test_invalid_log_level_defaults_to_debug(self, *unused):
         bad_log_config = MINIMAL_CONFIG.copy()
         bad_log_config["log-level"] = "bad-level"
         with self.assertLogs(level="ERROR") as logger:
@@ -59,8 +62,9 @@ class TestCharm(unittest.TestCase):
         plan = self.harness.get_container_pebble_plan("prometheus")
         self.assertEqual(cli_arg(plan, "--log.level"), "debug")
 
+    @patch("ops.testing._TestingPebbleClient.remove_path")
     @patch("ops.testing._TestingPebbleClient.push")
-    def test_valid_log_level_is_accepted(self, _):
+    def test_valid_log_level_is_accepted(self, *unused):
         valid_log_config = MINIMAL_CONFIG.copy()
         valid_log_config["log-level"] = "warn"
         self.harness.update_config(valid_log_config)
@@ -68,8 +72,9 @@ class TestCharm(unittest.TestCase):
         plan = self.harness.get_container_pebble_plan("prometheus")
         self.assertEqual(cli_arg(plan, "--log.level"), "warn")
 
+    @patch("ops.testing._TestingPebbleClient.remove_path")
     @patch("ops.testing._TestingPebbleClient.push")
-    def test_ingress_relation_not_set(self, _):
+    def test_ingress_relation_not_set(self, *unused):
         self.harness.set_leader(True)
 
         valid_log_config = MINIMAL_CONFIG.copy()
@@ -78,8 +83,9 @@ class TestCharm(unittest.TestCase):
         plan = self.harness.get_container_pebble_plan("prometheus")
         self.assertIsNone(cli_arg(plan, "--web.external-url"))
 
+    @patch("ops.testing._TestingPebbleClient.remove_path")
     @patch("ops.testing._TestingPebbleClient.push")
-    def test_ingress_relation_set(self, _):
+    def test_ingress_relation_set(self, *unused):
         self.harness.set_leader(True)
 
         self.harness.update_config(MINIMAL_CONFIG.copy())
@@ -93,16 +99,18 @@ class TestCharm(unittest.TestCase):
             "http://prometheus-k8s:9090",
         )
 
+    @patch("ops.testing._TestingPebbleClient.remove_path")
     @patch("ops.testing._TestingPebbleClient.push")
-    def test_tsdb_compression_is_not_enabled_by_default(self, _):
+    def test_tsdb_compression_is_not_enabled_by_default(self, *unused):
         compress_config = MINIMAL_CONFIG.copy()
         self.harness.update_config(compress_config)
 
         plan = self.harness.get_container_pebble_plan("prometheus")
         self.assertEqual(cli_arg(plan, "--storage.tsdb.wal-compression"), None)
 
+    @patch("ops.testing._TestingPebbleClient.remove_path")
     @patch("ops.testing._TestingPebbleClient.push")
-    def test_tsdb_compression_can_be_enabled(self, _):
+    def test_tsdb_compression_can_be_enabled(self, *unused):
         compress_config = MINIMAL_CONFIG.copy()
         compress_config["tsdb-wal-compression"] = True
         self.harness.update_config(compress_config)
@@ -113,8 +121,9 @@ class TestCharm(unittest.TestCase):
             "--storage.tsdb.wal-compression",
         )
 
+    @patch("ops.testing._TestingPebbleClient.remove_path")
     @patch("ops.testing._TestingPebbleClient.push")
-    def test_valid_tsdb_retention_times_can_be_set(self, _):
+    def test_valid_tsdb_retention_times_can_be_set(self, *unused):
         retention_time_config = MINIMAL_CONFIG.copy()
         acceptable_units = ["y", "w", "d", "h", "m", "s"]
         for unit in acceptable_units:
@@ -125,8 +134,9 @@ class TestCharm(unittest.TestCase):
             plan = self.harness.get_container_pebble_plan("prometheus")
             self.assertEqual(cli_arg(plan, "--storage.tsdb.retention.time"), retention_time)
 
+    @patch("ops.testing._TestingPebbleClient.remove_path")
     @patch("ops.testing._TestingPebbleClient.push")
-    def test_invalid_tsdb_retention_times_can_not_be_set(self, _):
+    def test_invalid_tsdb_retention_times_can_not_be_set(self, *unused):
         retention_time_config = MINIMAL_CONFIG.copy()
 
         # invalid unit
@@ -151,8 +161,9 @@ class TestCharm(unittest.TestCase):
         plan = self.harness.get_container_pebble_plan("prometheus")
         self.assertEqual(cli_arg(plan, "--storage.tsdb.retention.time"), None)
 
+    @patch("ops.testing._TestingPebbleClient.remove_path")
     @patch("ops.testing._TestingPebbleClient.push")
-    def test_global_scrape_interval_can_be_set(self, push):
+    def test_global_scrape_interval_can_be_set(self, push, _):
         scrapeint_config = MINIMAL_CONFIG.copy()
         acceptable_units = ["y", "w", "d", "h", "m", "s"]
         for unit in acceptable_units:
@@ -163,8 +174,9 @@ class TestCharm(unittest.TestCase):
             self.assertEqual(gconfig["scrape_interval"], scrapeint_config["scrape-interval"])
             push.reset()
 
+    @patch("ops.testing._TestingPebbleClient.remove_path")
     @patch("ops.testing._TestingPebbleClient.push")
-    def test_global_scrape_timeout_can_be_set(self, push):
+    def test_global_scrape_timeout_can_be_set(self, push, _):
         scrapetime_config = MINIMAL_CONFIG.copy()
         acceptable_units = ["y", "w", "d", "h", "m", "s"]
         for unit in acceptable_units:
@@ -175,8 +187,9 @@ class TestCharm(unittest.TestCase):
             self.assertEqual(gconfig["scrape_timeout"], scrapetime_config["scrape-timeout"])
             push.reset()
 
+    @patch("ops.testing._TestingPebbleClient.remove_path")
     @patch("ops.testing._TestingPebbleClient.push")
-    def test_global_evaluation_interval_can_be_set(self, push):
+    def test_global_evaluation_interval_can_be_set(self, push, _):
         evalint_config = MINIMAL_CONFIG.copy()
         acceptable_units = ["y", "w", "d", "h", "m", "s"]
         for unit in acceptable_units:
@@ -187,8 +200,9 @@ class TestCharm(unittest.TestCase):
             gconfig = global_config(config)
             self.assertEqual(gconfig["evaluation_interval"], evalint_config["evaluation-interval"])
 
+    @patch("ops.testing._TestingPebbleClient.remove_path")
     @patch("ops.testing._TestingPebbleClient.push")
-    def test_valid_external_labels_can_be_set(self, push):
+    def test_valid_external_labels_can_be_set(self, push, _):
         label_config = MINIMAL_CONFIG.copy()
         labels = {"name1": "value1", "name2": "value2"}
         label_config["external-labels"] = json.dumps(labels)
@@ -198,8 +212,9 @@ class TestCharm(unittest.TestCase):
         self.assertIsNotNone(gconfig["external_labels"])
         self.assertEqual(labels, gconfig["external_labels"])
 
+    @patch("ops.testing._TestingPebbleClient.remove_path")
     @patch("ops.testing._TestingPebbleClient.push")
-    def test_invalid_external_labels_can_not_be_set(self, push):
+    def test_invalid_external_labels_can_not_be_set(self, push, _):
         label_config = MINIMAL_CONFIG.copy()
         # label value must be string
         labels = {"name": 1}
@@ -213,8 +228,9 @@ class TestCharm(unittest.TestCase):
         gconfig = global_config(config)
         self.assertIsNone(gconfig.get("external_labels"))
 
+    @patch("ops.testing._TestingPebbleClient.remove_path")
     @patch("ops.testing._TestingPebbleClient.push")
-    def test_default_scrape_config_is_always_set(self, push):
+    def test_default_scrape_config_is_always_set(self, push, _):
         self.harness.update_config(MINIMAL_CONFIG)
         config = push.call_args[0]
         prometheus_scrape_config = scrape_config(config, "prometheus")

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -222,18 +222,20 @@ class TestCharm(unittest.TestCase):
 
     @patch("prometheus_server.Prometheus.reload_configuration")
     @patch("ops.testing._TestingPebbleClient.push")
-    def test_configuration_reload(self, push, trigger_configuration_reload):
-        self.harness.update_config(MINIMAL_CONFIG)
-
+    @patch("ops.testing._TestingPebbleClient.remove_path")
+    def test_configuration_reload(self, push, trigger_configuration_reload, _):
+        self.harness.container_pebble_ready("prometheus")
         push.assert_called()
-        trigger_configuration_reload.assert_not_called()
+
+        self.harness.update_config(MINIMAL_CONFIG)
+        push.assert_called()
+        trigger_configuration_reload.assert_called()
 
         label_config = MINIMAL_CONFIG.copy()
         labels = {"name1": "value1", "name2": "value2"}
         label_config["external-labels"] = json.dumps(labels)
 
         self.harness.update_config(label_config)
-
         trigger_configuration_reload.assert_called()
 
 

--- a/tests/test_endpoint_consumer.py
+++ b/tests/test_endpoint_consumer.py
@@ -112,7 +112,7 @@ OTHER_SCRAPE_METADATA = {
 ALLOWED_KEYS = {"job_name", "metrics_path", "static_configs", "relabel_configs"}
 
 
-class PrometheusCharm(CharmBase):
+class EndpointConsumerCharm(CharmBase):
     _stored = StoredState()
 
     def __init__(self, *args, **kwargs):
@@ -129,9 +129,9 @@ class PrometheusCharm(CharmBase):
         return "1.0.0"
 
 
-class TestProvider(unittest.TestCase):
+class TestEndpointConsumer(unittest.TestCase):
     def setUp(self):
-        self.harness = Harness(PrometheusCharm)
+        self.harness = Harness(EndpointConsumerCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
 

--- a/tests/test_endpoint_provider.py
+++ b/tests/test_endpoint_provider.py
@@ -48,7 +48,7 @@ JOBS = [
 ALLOWED_KEYS = {"job_name", "metrics_path", "static_configs"}
 
 
-class ConsumerCharm(CharmBase):
+class EndpointProviderCharm(CharmBase):
     _stored = StoredState()
 
     def __init__(self, *args, **kwargs):
@@ -63,9 +63,9 @@ class ConsumerCharm(CharmBase):
         self.provider._ALERT_RULES_PATH = "./tests/prometheus_alert_rules"
 
 
-class TestConsumer(unittest.TestCase):
+class TestEndpointProvider(unittest.TestCase):
     def setUp(self):
-        self.harness = Harness(ConsumerCharm, meta=CONSUMER_META)
+        self.harness = Harness(EndpointProviderCharm, meta=CONSUMER_META)
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(True)
         self.harness.begin()
@@ -177,7 +177,7 @@ class TestConsumer(unittest.TestCase):
 
 class TestBadConsumers(unittest.TestCase):
     def setUp(self):
-        self.harness = Harness(ConsumerCharm, meta=CONSUMER_META)
+        self.harness = Harness(EndpointProviderCharm, meta=CONSUMER_META)
         self.addCleanup(self.harness.cleanup)
         self.harness.set_leader(True)
         self.harness.begin()


### PR DESCRIPTION
- This commit fixes a typo that crept through a recent pull request. The typo resulted in a bug because the name of consumer object was not correct.
- This commit also address the fact that this bug silently passed through all unit tests. This was because the relevant parts of code were guarded by a inappropriately used `prometheus_ready` check that was not being triggered. This check is obsolete since the reversal of roles of provider and consumer and now has been removed.
- This commit also refactors the code that switches between reloading and restarting Prometheus following the example of Juju SDK docs.