### PR TITLE
Use pyproject.toml, simplify tox.ini

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,12 +1,14 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
 type: charm
 bases:
   - build-on:
-    - name: "ubuntu"
-      channel: "20.04"
+      - name: "ubuntu"
+        channel: "20.04"
     run-on:
-    - name: "ubuntu"
-      channel: "20.04"
+      - name: "ubuntu"
+        channel: "20.04"
 parts:
   charm:
     build-packages:
-    - git
+      - git

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,5 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
 options:
   log-level:
     description: |
@@ -35,4 +37,3 @@ options:
       How frequently rules will be evaluated.
     type: string
     default: 1m
-

--- a/lib/charms/prometheus_k8s/v0/prometheus.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus.py
@@ -1,4 +1,6 @@
-"""## Overview
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""## Overview.
 
 This document explains how to integrate with the Prometheus charm
 for the purposes of providing a metrics endpoint to Prometheus. It
@@ -234,7 +236,7 @@ charms when using this library, from a directory conventionally named
 in the `src` folder of the consumer charm. Each file in this directory
 is assumed to be a single alert rule in YAML format. The file name must
 have the `.rule` extension. The format of this alert rule conforms to the
-[Prometheus documentation](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
+[Prometheus docs](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
 An example of the contents of one such file is shown below.
 
 ```
@@ -347,6 +349,8 @@ class MonitoringEvents(ConsumerEvents):
 
 
 class MetricsEndpointConsumer(ConsumerBase):
+    """A Prometheus based Monitoring service provider."""
+
     on = MonitoringEvents()
 
     def __init__(self, charm, name):
@@ -689,6 +693,8 @@ class MetricsEndpointConsumer(ConsumerBase):
 
 
 class MetricsEndpointProvider(ProviderBase):
+    """Construct a metrics provider for a Prometheus charm."""
+
     def __init__(
         self,
         charm,
@@ -783,7 +789,7 @@ class MetricsEndpointProvider(ProviderBase):
             )
 
     def _set_unit_ip(self, event):
-        """Set unit host address
+        """Set unit host address.
 
         Each time a metrics provider charm container is restarted it updates its own
         host address in the unit relation data for the Prometheus charm.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,8 +1,10 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
 name: prometheus-k8s
 display-name: Prometheus
 summary: Prometheus for Kubernetes clusters
 maintainers:
-    - Balbir Thomas <balbir.thomas@canonical.com>
+  - Balbir Thomas <balbir.thomas@canonical.com>
 description: |
   Prometheus is an open source monitoring solution. Prometheus
   supports aggregating high dimensional data and exposes a powerful
@@ -20,15 +22,15 @@ containers:
       - storage: database
         location: /var/lib/prometheus
 provides:
-    grafana-source:
-        interface: grafana_datasource
+  grafana-source:
+    interface: grafana_datasource
 requires:
-    metrics-endpoint:
-        interface: prometheus_scrape
-    alertmanager:
-        interface: alertmanager_dispatch
-    ingress:
-        interface: ingress
+  metrics-endpoint:
+    interface: prometheus_scrape
+  alertmanager:
+    interface: alertmanager_dispatch
+  ingress:
+    interface: ingress
 storage:
   database:
     type: filesystem

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+[project]
+name = "prometheus-operator"
+description = "Kubernetes charm for Prometheus"
+license = "Apache 2.0"
+python = "^3.8"
+readme = "README.md"
+homepage = "https://charmhub.io/prometheus-k8s"
+repository = "https://github.com/canonical/prometheus-operator"
+documentation = "https://charmhub.io/prometheus-k8s/docs"
+
+# Testing tools configuration
+[tool.coverage.run]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+
+# Formatting tools configuration
+[tool.black]
+line-length = 99
+target-version = ["py38"]
+
+[tool.isort]
+profile = "black"
+
+# Linting tools configuration
+[tool.flake8]
+max-line-length = 99
+max-doc-length = 99
+max-complexity = 10
+exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
+select = ["E", "W", "F", "C", "N", "R", "D", "H"]
+# Ignore W503, E501 because using black creates errors with this
+# Ignore D107 Missing docstring in __init__
+ignore = ["W503", "E501", "D107", "E203"]
+# D100, D101, D102, D103: Ignore missing docstrings in tests
+per-file-ignores = ["tests/*:D100,D101,D102,D103,D104,C801"]
+docstring-convention = "google"
+# Check for properly formatted copyright header in each file
+copyright-check = "True"
+copyright-author = "Canonical Ltd."
+copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"

--- a/src/kubernetes_service.py
+++ b/src/kubernetes_service.py
@@ -1,5 +1,11 @@
-import kubernetes
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""A simple class used for patching incorrect Kubernetes Service definitions created by Juju."""
+
 from typing import List, Tuple
+
+import kubernetes
 
 
 class PatchFailed(RuntimeError):
@@ -17,7 +23,7 @@ class K8sServicePatch:
 
     @staticmethod
     def namespace() -> str:
-        """Read the Kubernetes namespace we're deployed in from the mounted service token
+        """Read the Kubernetes namespace we're deployed in from the mounted service token.
 
         Returns:
             str: The current Kubernetes namespace
@@ -27,7 +33,7 @@ class K8sServicePatch:
 
     @staticmethod
     def _k8s_auth():
-        """Authenticate with the Kubernetes API using an in-cluster service token
+        """Authenticate with the Kubernetes API using an in-cluster service token.
 
         Raises:
             PatchFailed: if no permissions to read cluster role
@@ -51,16 +57,16 @@ class K8sServicePatch:
     def _k8s_service(
         app: str, service_ports: List[Tuple[str, int, int]]
     ) -> kubernetes.client.V1Service:
-        """Property accessor to return a valid Kubernetes Service representation for Alertmanager
+        """Property accessor to return a valid Kubernetes Service representation for Alertmanager.
 
         Args:
             app: app name
             service_ports: a list of tuples (name, port, target_port) for every service port.
 
         Returns:
-            kubernetes.client.V1Service: A Kubernetes Service with correctly annotated metadata and ports
+            kubernetes.client.V1Service: A Kubernetes Service with correctly annotated metadata and
+            ports.
         """
-
         ports = [
             kubernetes.client.V1ServicePort(name=port[0], port=port[1], target_port=port[2])
             for port in service_ports
@@ -82,14 +88,14 @@ class K8sServicePatch:
 
     @staticmethod
     def set_ports(app: str, service_ports: List[Tuple[str, int, int]]):
-        """Patch the Kubernetes service created by Juju to map the correct port
+        """Patch the Kubernetes service created by Juju to map the correct port.
 
         Currently, Juju uses port 65535 for all endpoints. This can be observed via:
 
             kubectl describe services -n <model_name> | grep Port -C 2
 
-        At runtime, pebble watches which ports are bound and we need to patch the gap for pebble not telling Juju to fix
-        the K8S Service definition.
+        At runtime, pebble watches which ports are bound and we need to patch the gap for pebble
+        not telling Juju to fix the K8S Service definition.
 
         Typical usage example from within charm code (e.g. on_install):
 

--- a/src/prometheus_server.py
+++ b/src/prometheus_server.py
@@ -1,4 +1,10 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Helper for interacting with Prometheus throughout the charm's lifecycle."""
+
 import logging
+
 from requests import get, post
 from requests.exceptions import ConnectionError, ConnectTimeout
 
@@ -6,18 +12,24 @@ logger = logging.getLogger(__name__)
 
 
 class Prometheus:
+    """A class that represents a running instance of Prometheus."""
+
     def __init__(self, host: str = "localhost", port: int = 9090, api_timeout=2.0):
         """Utility to manage a Prometheus application.
+
         Args:
             host: Optional; host address of Prometheus application.
             port: Optional; port on which Prometheus service is exposed.
+            api_timeout: Optional; timeout (in seconds) to observe when interacting with the API.
         """
         self.base_url = f"http://{host}:{port}"
         self.api_timeout = api_timeout
 
     def reload_configuration(self) -> bool:
         """Send a POST request to to hot-reload the config.
+
         This reduces down-time compared to restarting the service.
+
         Returns:
           True if reload succeeded (returned 200 OK); False otherwise.
         """

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -1,12 +1,13 @@
 # Copyright 2020 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import unittest
-import yaml
 import json
-
+import unittest
 from unittest.mock import patch
+
+import yaml
 from ops.testing import Harness
+
 from charm import PrometheusCharm
 
 MINIMAL_CONFIG = {"prometheus-image-path": "prom/prometheus"}
@@ -27,8 +28,8 @@ class TestCharm(unittest.TestCase):
     @patch("ops.testing._TestingModelBackend.network_get")
     def test_grafana_is_provided_port_and_source(self, mock_net_get, *unused):
         self.harness.update_config(MINIMAL_CONFIG)
-        IP = "1.1.1.1"
-        net_info = {"bind-addresses": [{"interface-name": "ens1", "addresses": [{"value": IP}]}]}
+        ip = "1.1.1.1"
+        net_info = {"bind-addresses": [{"interface-name": "ens1", "addresses": [{"value": ip}]}]}
         mock_net_get.return_value = net_info
 
         rel_id = self.harness.add_relation("grafana-source", "grafana")
@@ -36,7 +37,7 @@ class TestCharm(unittest.TestCase):
         grafana_host = self.harness.get_relation_data(rel_id, self.harness.model.unit.name)[
             "grafana_source_host"
         ]
-        self.assertEqual(grafana_host, "{}:{}".format(IP, "9090"))
+        self.assertEqual(grafana_host, "{}:{}".format(ip, "9090"))
 
     @patch("ops.testing._TestingPebbleClient.remove_path")
     @patch("ops.testing._TestingPebbleClient.push")

--- a/tests/test_endpoint_consumer.py
+++ b/tests/test_endpoint_consumer.py
@@ -4,10 +4,10 @@
 import json
 import unittest
 
+from charms.prometheus_k8s.v0.prometheus import MetricsEndpointConsumer
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.testing import Harness
-from charms.prometheus_k8s.v0.prometheus import MetricsEndpointConsumer
 
 RELATION_NAME = "metrics-endpoint"
 DEFAULT_JOBS = [{"metrics_path": "/metrics"}]
@@ -373,16 +373,16 @@ class TestEndpointConsumer(unittest.TestCase):
     def test_provider_logs_an_error_on_missing_alerting_data(self):
         self.assertEqual(self.harness.charm._stored.num_events, 0)
 
-        BAD_METADATA = {"bad": "metadata"}
-        BAD_RULES = {"bad": "rule"}
+        bad_metadata = {"bad": "metadata"}
+        bad_rules = {"bad": "rule"}
 
         rel_id = self.harness.add_relation(RELATION_NAME, "consumer")
         self.harness.update_relation_data(
             rel_id,
             "consumer",
             {
-                "scrape_metadata": json.dumps(BAD_METADATA),
-                "alert_rules": json.dumps(BAD_RULES),
+                "scrape_metadata": json.dumps(bad_metadata),
+                "alert_rules": json.dumps(bad_rules),
             },
         )
         self.harness.add_relation_unit(rel_id, "consumer/0")

--- a/tests/test_endpoint_provider.py
+++ b/tests/test_endpoint_provider.py
@@ -6,12 +6,10 @@ import re
 import unittest
 from unittest.mock import patch
 
+from charms.prometheus_k8s.v0.prometheus import MetricsEndpointProvider
 from ops.charm import CharmBase
 from ops.framework import StoredState
-
 from ops.testing import Harness
-from charms.prometheus_k8s.v0.prometheus import MetricsEndpointProvider
-
 
 RELATION_NAME = "metrics-endpoint"
 CONSUMER_SERVICE = "prometheus_tester"

--- a/tests/test_kubernetes_service.py
+++ b/tests/test_kubernetes_service.py
@@ -1,7 +1,10 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
 import unittest
 from unittest.mock import patch
 
 import kubernetes
+
 from kubernetes_service import K8sServicePatch, PatchFailed
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,8 +1,9 @@
 # Copyright 2020 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import responses
 import unittest
+
+import responses
 
 from prometheus_server import Prometheus
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,43 +1,66 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
 [tox]
 skipsdist=True
 skip_missing_interpreters = True
 envlist = lint, unit
 
-[flake8]
-exclude =
-    *.egg_info
-    .git,
-    .tox,
-    __pycache__,
-    build,
-    dist,
-    venv
-max-line-length = 99
-max-complexity = 10
-select = E,W,F,C,N
-# Ignore W503, E501, E203 because using black creates errors with this
-ignore = W503,E501,E203
+[vars]
+src_path = {toxinidir}/src/
+tst_path = {toxinidir}/tests/
+lib_path = {toxinidir}/lib/charms/prometheus_k8s/
+all_path = {[vars]src_path} {[vars]tst_path} {[vars]lib_path}
 
 [testenv]
 basepython = python3
 setenv =
-  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{toxinidir}/src
+  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
   PYTHONBREAKPOINT=ipdb.set_trace
+passenv =
+  PYTHONPATH
+  HOME
+  PATH
+  CHARM_BUILD_DIR
+  MODEL_SETTINGS
+  HTTP_PROXY
+  HTTPS_PROXY
+  NO_PROXY
+
+[testenv:fmt]
+description = Apply coding style standards to code
+deps =
+    black
+    isort
+commands =
+    isort {[vars]all_path}
+    black {[vars]all_path}
 
 [testenv:lint]
+description = Check code against coding style standards
 deps =
     black
     flake8
+    flake8-docstrings
+    flake8-copyright
+    flake8-builtins
+    pyproject-flake8
+    pep8-naming
+    isort
 commands =
-    flake8 {toxinidir}/src {toxinidir}/tests {toxinidir}/lib/charms/prometheus_k8s
-    black --line-length=99 --check --diff --target-version=py38 {toxinidir}/src {toxinidir}/tests {toxinidir}/lib/charms/prometheus_k8s
+    # pflake8 wrapper suppports config from pyproject.toml
+    pflake8 {[vars]all_path}
+    isort --check-only --diff {[vars]all_path}
+    black --check --diff {[vars]all_path}
 
 [testenv:unit]
-deps = 
+description = Run unit tests
+deps =
     pytest
     coverage
     responses
     -r{toxinidir}/requirements.txt
 commands =
-    coverage run --branch --source={toxinidir}/src,{toxinidir}/lib/charms/prometheus_k8s -m pytest -v --tb native {posargs} {toxinidir}/tests 
-    coverage report -m
+    coverage run \
+      --source={[vars]src_path},{[vars]lib_path} \
+      -m pytest -v --tb native {posargs} {[vars]tst_path}
+    coverage report


### PR DESCRIPTION
This PR implements a `pyproject.toml` file to seperate out tool config and test env definitions. In the first commit, these changes are completed.

In the second commit, minor adjustments to docstrings, whitespace and variable names are made to ensure the code is compliant with the selected linting rules.