### PR TITLE
Remove provider consumer

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus.py
@@ -356,7 +356,6 @@ class MetricsEndpointConsumer(Object):
         super().__init__(charm, name)
         self._charm = charm
         self._relation_name = name
-        # TODO: use ConsumerBase events when ProviderAvailable exposes relation ID
         events = self._charm.on[name]
         self.framework.observe(events.relation_changed, self._on_metrics_provider_relation_changed)
         self.framework.observe(

--- a/lib/charms/prometheus_k8s/v0/prometheus.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus.py
@@ -292,8 +292,7 @@ import logging
 from pathlib import Path
 
 import yaml
-from ops.framework import EventBase, EventSource
-from ops.relation import ConsumerBase, ConsumerEvents, ProviderBase
+from ops.framework import EventBase, EventSource, Object, ObjectEvents
 
 # The unique Charmhub library identifier, never change it
 LIBID = "bc84295fef5f4049878f07b131968ee2"
@@ -342,13 +341,13 @@ class TargetsChangedEvent(EventBase):
         self.relation_id = snapshot["relation_id"]
 
 
-class MonitoringEvents(ConsumerEvents):
+class MonitoringEvents(ObjectEvents):
     """Event descriptor for events raised by `MetricsEndpointConsumer`."""
 
     targets_changed = EventSource(TargetsChangedEvent)
 
 
-class MetricsEndpointConsumer(ConsumerBase):
+class MetricsEndpointConsumer(Object):
     """A Prometheus based Monitoring service provider."""
 
     on = MonitoringEvents()
@@ -362,7 +361,7 @@ class MetricsEndpointConsumer(ConsumerBase):
             name: string name of the relation over which scrape target
                 information is gathered by the Prometheus charm.
         """
-        super().__init__(charm, name, {"openmetrics": None}, multi=True)
+        super().__init__(charm, name)
         self._charm = charm
         self._relation_name = name
         # TODO: use ConsumerBase events when ProviderAvailable exposes relation ID
@@ -692,7 +691,7 @@ class MetricsEndpointConsumer(ConsumerBase):
         return static_config
 
 
-class MetricsEndpointProvider(ProviderBase):
+class MetricsEndpointProvider(Object):
     """Construct a metrics provider for a Prometheus charm."""
 
     def __init__(
@@ -745,7 +744,7 @@ class MetricsEndpointProvider(ProviderBase):
                 files.  Defaults to "src/prometheus_alert_rules" at the top level
                 of the charm repository.
         """
-        super().__init__(charm, name, "openmetrics")
+        super().__init__(charm, name)
 
         self._charm = charm
         self._ALERT_RULES_PATH = alert_rules_path

--- a/lib/charms/prometheus_k8s/v0/prometheus.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus.py
@@ -14,26 +14,25 @@ provide a scrape target for Prometheus.
 ## Provider Library Usage
 
 This Prometheus charm interacts with its scrape targets using its
-charm library. This charm library is constructed using the [Provider
-and Consumer](https://ops.readthedocs.io/en/latest/#module-ops.relation)
-objects from the Operator Framework. This implies charms seeking to
-expose a metric endpoints for the Prometheus charm, must do so using
-the `MetricsEndpointProvider` object from this charm library. For the simplest
-use cases, using the `MetricsEndpointProvider` object only requires
-instantiating it, typically in the constructor of your charm (the one
-which exposes a metrics endpoint). The `MetricsEndpointProvider` constructor
-requires the name of the relation over which a scrape target (metrics
-endpoint) is exposed to the Prometheus charm. This relation must use
-the `prometheus_scrape` interface. The address of the metrics endpoint
-is set to the unit address, by each unit of the `MetricsEndpointProvider`
+charm library. Charms seeking to expose a metric endpoints for the
+Prometheus charm, must do so using the `MetricsEndpointProvider`
+object from this charm library. For the simplest use cases, using the
+`MetricsEndpointProvider` object only requires instantiating it,
+typically in the constructor of your charm (the one which exposes a
+metrics endpoint). The `MetricsEndpointProvider` constructor requires
+the name of the relation over which a scrape target (metrics endpoint)
+is exposed to the Prometheus charm. This relation must use the
+`prometheus_scrape` interface. The address of the metrics endpoint is
+set to the unit address, by each unit of the `MetricsEndpointProvider`
 charm. These units set their address in response to a specific
-`CharmEvent`. Hence instantiating the `MetricsEndpointProvider` also requires
-a `CharmEvent` object in response to which each unit will post its
-address into the unit's relation data for the Prometheus charm. Since
-container restarts of Kubernetes charms can result in change of IP
-addresses, this event is typically `PebbleReady`. For example,
-assuming your charm exposes a metrics endpoint over a relation named
-"metrics_endpoint", you may instantiate `MetricsEndpointProvider` as follows
+`CharmEvent`. Hence instantiating the `MetricsEndpointProvider` also
+requires a `CharmEvent` object in response to which each unit will
+post its address into the unit's relation data for the Prometheus
+charm. Since container restarts of Kubernetes charms can result in
+change of IP addresses, this event is typically `PebbleReady`. For
+example, assuming your charm exposes a metrics endpoint over a
+relation named "metrics_endpoint", you may instantiate
+`MetricsEndpointProvider` as follows
 
     from charms.prometheus_k8s.v0.prometheus import MetricsEndpointProvider
 
@@ -42,19 +41,12 @@ assuming your charm exposes a metrics endpoint over a relation named
         ...
         self.metrics_endpoint = MetricsEndpointProvider(self, "metrics-endpoint",
                                                 self.on.container_name_pebble_ready)
-        self.metrics_endpoint.ready()
         ...
 
 In this example `container_name_pebble_ready` is the `PebbleReady` event
 in response to which each unit will advertise its address. Also note
 that the first argument (`self`) to `MetricsEndpointProvider` is always a
-reference to the parent (scrape target) charm. Also note the
-invocation of the `ready()` method on `MetricsEndpointProvider`. This signals
-to the Prometheus charm that the metrics endpoint is active and can be
-scraped. It is not necessary to invoke `ready()` immediately after
-instantiating `MetricsEndpointProvider`. There is also a corresponding
-`unready()` that can be used to signal temporary suspension of
-scrapping by the Prometheus charm.
+reference to the parent (scrape target) charm.
 
 An instantiated `MetricsEndpointProvider` object will ensure that each unit of
 its parent charm, is a scrape target for the `MetricsEndpointConsumer`


### PR DESCRIPTION
This pull request removes any dependence on `ops.relation` and updates the docs.