### PR TITLE
Update CONTRIBUTING.md - fix packed charm filename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ $ charmcraft pack
 ### Deploy
 
 ```bash
-$ juju deploy ./prometheus-k8s.charm --resource prometheus-image=ubuntu/prometheus:latest
+$ juju deploy ./prometheus-k8s_ubuntu-20.04-amd64.charm --resource prometheus-image=ubuntu/prometheus:latest
 ```
 
 ## Linting


### PR DESCRIPTION
The `CONTRIBUTING.md` has an incorrect filename for the default name of the packed charm when using later versions of `charmcraft`.