### PR TITLE
A new Prometheus Aggregator Object

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus.py
@@ -294,7 +294,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 logger = logging.getLogger(__name__)

--- a/lib/charms/prometheus_k8s/v0/prometheus.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus.py
@@ -898,7 +898,7 @@ class MetricsEndpointProvider(Object):
 
 
 class MetricsEndpointAggregator(Object):
-    """Aggregate metrics from multiple scrape targets
+    """Aggregate metrics from multiple scrape targets.
 
     `MetricsEndpointAggregator` collects scrape target information from one
     or more related charms and forwards this to a `MetricsEndpointConsumer`

--- a/lib/charms/prometheus_k8s/v0/prometheus.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus.py
@@ -969,7 +969,17 @@ class MetricsEndpointAggregator(ProviderBase):
         for relation in self.model.relations[self._target_relation]:
             if targets := self._get_targets(relation):
                 jobs.append(self._static_scrape_job(targets, relation.app.name))
+
+        groups = []
+        for relation in self.model.relations[self._alert_rules_relation]:
+            if unit_rules := self._get_alert_rules(relation):
+                appname = relation.app.name
+                unit_rules = self._label_alert_rules(unit_rules, appname)
+                group = {"name": self._group_name(appname), "rules": unit_rules}
+                groups.append(group)
+
         event.relation.data[self._charm.app]["scrape_jobs"] = json.dumps(jobs)
+        event.relation.data[self._charm.app]["alert_rules"] = json.dumps({"groups": groups})
 
     def _update_prometheus_jobs(self, event):
         if not (targets := self._get_targets(event.relation)):

--- a/lib/charms/prometheus_k8s/v0/prometheus.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus.py
@@ -897,7 +897,7 @@ class MetricsEndpointProvider(Object):
         return metadata
 
 
-class MetricsEndpointAggregator(ProviderBase):
+class MetricsEndpointAggregator(Object):
     """Aggregate metrics from multiple scrape targets
 
     `MetricsEndpointAggregator` collects scrape target information from one
@@ -945,7 +945,7 @@ class MetricsEndpointAggregator(ProviderBase):
     """
 
     def __init__(self, charm, relation_names, multi=False):
-        super().__init__(charm, relation_names["prometheus"], "openmetrics", multi)
+        super().__init__(charm, relation_names["prometheus"])
 
         self._charm = charm
         self._target_relation = relation_names["scrape_target"]

--- a/src/charm.py
+++ b/src/charm.py
@@ -138,16 +138,10 @@ class PrometheusCharm(CharmBase):
         """
         container.remove_path(RULES_DIR, recursive=True)
 
-        for rel_id, alert_rules in self.metrics_consumer.alerts().items():
-            filename = "juju_{}_{}_{}_rel_{}_alert.rules".format(
-                alert_rules["model"],
-                alert_rules["model_uuid"],
-                alert_rules["application"],
-                rel_id,
-            )
-
+        for group_name, group in self.metrics_consumer.alerts().items():
+            filename = "juju_" + group_name + ".rules"
             path = os.path.join(RULES_DIR, filename)
-            rules = yaml.dump({"groups": alert_rules["groups"]})
+            rules = yaml.dump({"groups": [group]})
 
             container.push(path, rules, make_dirs=True)
             logger.debug("Updated alert rules file %s", filename)

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,7 +16,7 @@ from charms.prometheus_k8s.v0.prometheus import MetricsEndpointConsumer
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import Layer
 
 from kubernetes_service import K8sServicePatch, PatchFailed
@@ -103,6 +103,7 @@ class PrometheusCharm(CharmBase):
         container = self.unit.get_container(self._name)
 
         if not container.can_connect():
+            self.unit.status = WaitingStatus("Waiting for Pebble ready")
             return
 
         # push Prometheus config file to workload

--- a/tests/test_endpoint_aggregator.py
+++ b/tests/test_endpoint_aggregator.py
@@ -25,6 +25,18 @@ requires:
     interface: prometheus-rules
 """
 
+RELABEL_INSTANCE_CONFIG = {
+    "source_labels": [
+        "juju_model",
+        "juju_model_uuid",
+        "juju_application",
+        "juju_unit",
+    ],
+    "separator": "_",
+    "target_label": "instance",
+    "regex": "(.*)",
+}
+
 ALERT_RULE_1 = """- alert: CPU_Usage
   expr: cpu_usage_idle{is_container!=\"True\", group=\"promoagents-juju\"} < 10
   for: 5m
@@ -110,6 +122,7 @@ class TestEndpointAggregator(unittest.TestCase):
                         },
                     }
                 ],
+                "relabel_configs": [RELABEL_INSTANCE_CONFIG],
             }
         ]
         self.assertListEqual(scrape_jobs, expected_jobs)
@@ -195,6 +208,7 @@ class TestEndpointAggregator(unittest.TestCase):
                         },
                     }
                 ],
+                "relabel_configs": [RELABEL_INSTANCE_CONFIG],
             }
         ]
         self.assertListEqual(scrape_jobs, expected_jobs)
@@ -290,6 +304,7 @@ class TestEndpointAggregator(unittest.TestCase):
                         },
                     }
                 ],
+                "relabel_configs": [RELABEL_INSTANCE_CONFIG],
             },
             {
                 "job_name": "juju_testmodel_1234567_target-app-2_prometheus_scrape",
@@ -305,6 +320,7 @@ class TestEndpointAggregator(unittest.TestCase):
                         },
                     }
                 ],
+                "relabel_configs": [RELABEL_INSTANCE_CONFIG],
             },
         ]
 
@@ -436,6 +452,7 @@ class TestEndpointAggregator(unittest.TestCase):
                         },
                     }
                 ],
+                "relabel_configs": [RELABEL_INSTANCE_CONFIG],
             }
         ]
         self.assertListEqual(scrape_jobs, expected_jobs)
@@ -555,6 +572,7 @@ class TestEndpointAggregator(unittest.TestCase):
                         },
                     }
                 ],
+                "relabel_configs": [RELABEL_INSTANCE_CONFIG],
             }
         ]
         self.assertListEqual(scrape_jobs, expected_jobs)

--- a/tests/test_endpoint_aggregator.py
+++ b/tests/test_endpoint_aggregator.py
@@ -1,0 +1,623 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import json
+import unittest
+
+from ops.charm import CharmBase
+from ops.testing import Harness
+
+from charms.prometheus_k8s.v0.prometheus import MetricsEndpointAggregator
+
+
+PROMETHEUS_RELATION = "metrics-endpoint"
+SCRAPE_TARGET_RELATION = "prometheus-target"
+ALERT_RULES_RELATION = "prometheus-rules"
+AGGREGATOR_META = f"""
+name: aggregator-tester
+containers:
+  aggregator-tester:
+provides:
+  {PROMETHEUS_RELATION}:
+    interface: prometheus_scrape
+requires:
+  {SCRAPE_TARGET_RELATION}:
+    interface: http
+  {ALERT_RULES_RELATION}:
+    interface: prometheus-rules
+"""
+
+ALERT_RULE_1 = """- alert: CPU_Usage
+  expr: cpu_usage_idle{is_container!=\"True\", group=\"promoagents-juju\"} < 10
+  for: 5m
+  labels:
+    override_group_by: host
+    severity: page
+    cloud: juju
+  annotations:
+    description: |
+      Host {{ $labels.host }} has had <  10% idle cpu for the last 5m
+    summary: Host {{ $labels.host }} CPU free is less than 10%
+"""
+ALERT_RULE_2 = """- alert: DiskFull
+  expr: disk_free{is_container!=\"True\", fstype!~\".*tmpfs|squashfs|overlay\"}  <1024
+  for: 5m
+  labels:
+    override_group_by: host
+    severity: page
+  annotations:
+    description: |
+      Host {{ $labels.host}} {{ $labels.path }} is full
+      summary: Host {{ $labels.host }} {{ $labels.path}} is full
+"""
+
+
+class EndpointAggregatorCharm(CharmBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args)
+
+        relation_names = {
+            "prometheus": PROMETHEUS_RELATION,
+            "scrape_target": SCRAPE_TARGET_RELATION,
+            "alert_rules": ALERT_RULES_RELATION,
+        }
+        self._aggregator = MetricsEndpointAggregator(
+            self,
+            relation_names,
+        )
+
+
+class TestEndpointAggregator(unittest.TestCase):
+    def setUp(self):
+        self.harness = Harness(EndpointAggregatorCharm, meta=AGGREGATOR_META)
+        self.harness.set_model_info(name="testmodel", uuid="1234567890")
+        self.addCleanup(self.harness.cleanup)
+        self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
+
+    def test_adding_prometheus_then_target_forwards_a_labeled_scrape_job(self):
+        prometheus_rel_id = self.harness.add_relation(PROMETHEUS_RELATION, "prometheus")
+        self.harness.add_relation_unit(prometheus_rel_id, "prometheus/0")
+
+        target_rel_id = self.harness.add_relation(SCRAPE_TARGET_RELATION, "target-app")
+        self.harness.add_relation_unit(target_rel_id, "target-app/0")
+
+        hostname = "scrape_target_0"
+        port = "1234"
+        self.harness.update_relation_data(
+            target_rel_id,
+            "target-app/0",
+            {
+                "hostname": f"{hostname}",
+                "port": f"{port}",
+            },
+        )
+
+        prometheus_rel_data = self.harness.get_relation_data(
+            prometheus_rel_id, self.harness.model.app.name
+        )
+        scrape_jobs = json.loads(prometheus_rel_data.get("scrape_jobs", "[]"))
+        expected_jobs = [
+            {
+                "job_name": "juju_testmodel_1234567_target-app_prometheus_scrape",
+                "static_configs": [
+                    {
+                        "targets": ["scrape_target_0:1234"],
+                        "labels": {
+                            "juju_model": "testmodel",
+                            "juju_model_uuid": "1234567890",
+                            "juju_application": "target-app",
+                            "juju_unit": "target-app/0",
+                            "host": "scrape_target_0",
+                        },
+                    }
+                ],
+            }
+        ]
+        self.assertListEqual(scrape_jobs, expected_jobs)
+
+    def test_adding_prometheus_then_target_forwards_a_labeled_alert_rule(self):
+        prometheus_rel_id = self.harness.add_relation(PROMETHEUS_RELATION, "prometheus")
+        self.harness.add_relation_unit(prometheus_rel_id, "prometheus/0")
+
+        alert_rules_rel_id = self.harness.add_relation(ALERT_RULES_RELATION, "rules-app")
+        self.harness.add_relation_unit(alert_rules_rel_id, "rules-app/0")
+        self.harness.update_relation_data(
+            alert_rules_rel_id, "rules-app/0", {"groups": ALERT_RULE_1}
+        )
+
+        prometheus_rel_data = self.harness.get_relation_data(
+            prometheus_rel_id, self.harness.model.app.name
+        )
+
+        alert_rules = json.loads(prometheus_rel_data.get("alert_rules", "{}"))
+        groups = alert_rules.get("groups", [])
+        self.assertEqual(len(groups), 1)
+        group = groups[0]
+
+        expected_group = {
+            "name": "juju_testmodel_1234567_rules-app_alert_rules",
+            "rules": [
+                {
+                    "alert": "CPU_Usage",
+                    "expr": 'cpu_usage_idle{is_container!="True", group="promoagents-juju"} < 10',
+                    "for": "5m",
+                    "labels": {
+                        "override_group_by": "host",
+                        "severity": "page",
+                        "cloud": "juju",
+                        "juju_model": "testmodel",
+                        "juju_model_uuid": "1234567",
+                        "juju_application": "rules-app",
+                        "juju_unit": "rules-app/0",
+                    },
+                    "annotations": {
+                        "description": "Host {{ $labels.host }} has had <  10% idle cpu for the last 5m\n",
+                        "summary": "Host {{ $labels.host }} CPU free is less than 10%",
+                    },
+                }
+            ],
+        }
+        self.assertDictEqual(group, expected_group)
+
+    def test_adding_target_then_prometheus_forwards_a_labeled_scrape_job(self):
+        target_rel_id = self.harness.add_relation(SCRAPE_TARGET_RELATION, "target-app")
+        self.harness.add_relation_unit(target_rel_id, "target-app/0")
+
+        hostname = "scrape_target_0"
+        port = "1234"
+        self.harness.update_relation_data(
+            target_rel_id,
+            "target-app/0",
+            {
+                "hostname": f"{hostname}",
+                "port": f"{port}",
+            },
+        )
+
+        prometheus_rel_id = self.harness.add_relation(PROMETHEUS_RELATION, "prometheus")
+        self.harness.add_relation_unit(prometheus_rel_id, "prometheus/0")
+
+        prometheus_rel_data = self.harness.get_relation_data(
+            prometheus_rel_id, self.harness.model.app.name
+        )
+        scrape_jobs = json.loads(prometheus_rel_data.get("scrape_jobs", "[]"))
+        expected_jobs = [
+            {
+                "job_name": "juju_testmodel_1234567_target-app_prometheus_scrape",
+                "static_configs": [
+                    {
+                        "targets": ["scrape_target_0:1234"],
+                        "labels": {
+                            "juju_model": "testmodel",
+                            "juju_model_uuid": "1234567890",
+                            "juju_application": "target-app",
+                            "juju_unit": "target-app/0",
+                            "host": "scrape_target_0",
+                        },
+                    }
+                ],
+            }
+        ]
+        self.assertListEqual(scrape_jobs, expected_jobs)
+
+    def test_adding_target_then_prometheus_forwards_a_labeled_alert_rule(self):
+        prometheus_rel_id = self.harness.add_relation(PROMETHEUS_RELATION, "prometheus")
+        self.harness.add_relation_unit(prometheus_rel_id, "prometheus/0")
+
+        alert_rules_rel_id = self.harness.add_relation(ALERT_RULES_RELATION, "rules-app")
+        self.harness.add_relation_unit(alert_rules_rel_id, "rules-app/0")
+        self.harness.update_relation_data(
+            alert_rules_rel_id, "rules-app/0", {"groups": ALERT_RULE_1}
+        )
+
+        prometheus_rel_data = self.harness.get_relation_data(
+            prometheus_rel_id, self.harness.model.app.name
+        )
+
+        alert_rules = json.loads(prometheus_rel_data.get("alert_rules", "{}"))
+        groups = alert_rules.get("groups", [])
+        self.assertEqual(len(groups), 1)
+        group = groups[0]
+
+        expected_group = {
+            "name": "juju_testmodel_1234567_rules-app_alert_rules",
+            "rules": [
+                {
+                    "alert": "CPU_Usage",
+                    "expr": 'cpu_usage_idle{is_container!="True", group="promoagents-juju"} < 10',
+                    "for": "5m",
+                    "labels": {
+                        "override_group_by": "host",
+                        "severity": "page",
+                        "cloud": "juju",
+                        "juju_model": "testmodel",
+                        "juju_model_uuid": "1234567",
+                        "juju_application": "rules-app",
+                        "juju_unit": "rules-app/0",
+                    },
+                    "annotations": {
+                        "description": "Host {{ $labels.host }} has had <  10% idle cpu for the last 5m\n",
+                        "summary": "Host {{ $labels.host }} CPU free is less than 10%",
+                    },
+                }
+            ],
+        }
+        self.assertDictEqual(group, expected_group)
+
+    def test_scrape_jobs_from_multiple_target_applications_are_forwarded(self):
+        prometheus_rel_id = self.harness.add_relation(PROMETHEUS_RELATION, "prometheus")
+        self.harness.add_relation_unit(prometheus_rel_id, "prometheus/0")
+
+        target_rel_id_1 = self.harness.add_relation(SCRAPE_TARGET_RELATION, "target-app-1")
+        self.harness.add_relation_unit(target_rel_id_1, "target-app-1/0")
+        self.harness.update_relation_data(
+            target_rel_id_1,
+            "target-app-1/0",
+            {
+                "hostname": "scrape_target_0",
+                "port": "1234",
+            },
+        )
+
+        target_rel_id_2 = self.harness.add_relation(SCRAPE_TARGET_RELATION, "target-app-2")
+        self.harness.add_relation_unit(target_rel_id_2, "target-app-2/0")
+        self.harness.update_relation_data(
+            target_rel_id_2,
+            "target-app-2/0",
+            {
+                "hostname": "scrape_target_1",
+                "port": "5678",
+            },
+        )
+
+        prometheus_rel_data = self.harness.get_relation_data(
+            prometheus_rel_id, self.harness.model.app.name
+        )
+        scrape_jobs = json.loads(prometheus_rel_data.get("scrape_jobs", "[]"))
+        self.assertEqual(len(scrape_jobs), 2)
+
+        expected_jobs = [
+            {
+                "job_name": "juju_testmodel_1234567_target-app-1_prometheus_scrape",
+                "static_configs": [
+                    {
+                        "targets": ["scrape_target_0:1234"],
+                        "labels": {
+                            "juju_model": "testmodel",
+                            "juju_model_uuid": "1234567890",
+                            "juju_application": "target-app-1",
+                            "juju_unit": "target-app-1/0",
+                            "host": "scrape_target_0",
+                        },
+                    }
+                ],
+            },
+            {
+                "job_name": "juju_testmodel_1234567_target-app-2_prometheus_scrape",
+                "static_configs": [
+                    {
+                        "targets": ["scrape_target_1:5678"],
+                        "labels": {
+                            "juju_model": "testmodel",
+                            "juju_model_uuid": "1234567890",
+                            "juju_application": "target-app-2",
+                            "juju_unit": "target-app-2/0",
+                            "host": "scrape_target_1",
+                        },
+                    }
+                ],
+            },
+        ]
+
+        self.assertListEqual(scrape_jobs, expected_jobs)
+
+    def test_alert_rules_from_multiple_target_applications_are_forwarded(self):
+        prometheus_rel_id = self.harness.add_relation(PROMETHEUS_RELATION, "prometheus")
+        self.harness.add_relation_unit(prometheus_rel_id, "prometheus/0")
+
+        alert_rules_rel_id_1 = self.harness.add_relation(ALERT_RULES_RELATION, "rules-app-1")
+        self.harness.add_relation_unit(alert_rules_rel_id_1, "rules-app-1/0")
+        self.harness.update_relation_data(
+            alert_rules_rel_id_1,
+            "rules-app-1/0",
+            {"groups": ALERT_RULE_1},
+        )
+
+        alert_rules_rel_id_2 = self.harness.add_relation(ALERT_RULES_RELATION, "rules-app-2")
+        self.harness.add_relation_unit(alert_rules_rel_id_2, "rules-app-2/0")
+        self.harness.update_relation_data(
+            alert_rules_rel_id_2,
+            "rules-app-2/0",
+            {"groups": ALERT_RULE_2},
+        )
+
+        prometheus_rel_data = self.harness.get_relation_data(
+            prometheus_rel_id, self.harness.model.app.name
+        )
+
+        alert_rules = json.loads(prometheus_rel_data.get("alert_rules", "{}"))
+        groups = alert_rules.get("groups", [])
+        self.assertEqual(len(groups), 2)
+        expected_groups = [
+            {
+                "name": "juju_testmodel_1234567_rules-app-1_alert_rules",
+                "rules": [
+                    {
+                        "alert": "CPU_Usage",
+                        "expr": 'cpu_usage_idle{is_container!="True", group="promoagents-juju"} < 10',
+                        "for": "5m",
+                        "labels": {
+                            "override_group_by": "host",
+                            "severity": "page",
+                            "cloud": "juju",
+                            "juju_model": "testmodel",
+                            "juju_model_uuid": "1234567",
+                            "juju_application": "rules-app-1",
+                            "juju_unit": "rules-app-1/0",
+                        },
+                        "annotations": {
+                            "description": "Host {{ $labels.host }} has had <  10% idle cpu for the last 5m\n",
+                            "summary": "Host {{ $labels.host }} CPU free is less than 10%",
+                        },
+                    }
+                ],
+            },
+            {
+                "name": "juju_testmodel_1234567_rules-app-2_alert_rules",
+                "rules": [
+                    {
+                        "alert": "DiskFull",
+                        "expr": 'disk_free{is_container!="True", fstype!~".*tmpfs|squashfs|overlay"}  <1024',
+                        "for": "5m",
+                        "labels": {
+                            "override_group_by": "host",
+                            "severity": "page",
+                            "juju_model": "testmodel",
+                            "juju_model_uuid": "1234567",
+                            "juju_application": "rules-app-2",
+                            "juju_unit": "rules-app-2/0",
+                        },
+                        "annotations": {
+                            "description": "Host {{ $labels.host}} {{ $labels.path }} is full\nsummary: Host {{ $labels.host }} {{ $labels.path}} is full\n"
+                        },
+                    }
+                ],
+            },
+        ]
+        self.assertListEqual(groups, expected_groups)
+
+    def test_scrape_job_removal_differentiates_between_applications(self):
+        prometheus_rel_id = self.harness.add_relation(PROMETHEUS_RELATION, "prometheus")
+        self.harness.add_relation_unit(prometheus_rel_id, "prometheus/0")
+
+        target_rel_id_1 = self.harness.add_relation("prometheus-target", "target-app-1")
+        self.harness.add_relation_unit(target_rel_id_1, "target-app-1/0")
+        self.harness.update_relation_data(
+            target_rel_id_1,
+            "target-app-1/0",
+            {
+                "hostname": "scrape_target_0",
+                "port": "1234",
+            },
+        )
+
+        target_rel_id_2 = self.harness.add_relation("prometheus-target", "target-app-2")
+        self.harness.add_relation_unit(target_rel_id_2, "target-app-2/0")
+        self.harness.update_relation_data(
+            target_rel_id_2,
+            "target-app-2/0",
+            {
+                "hostname": "scrape_target_1",
+                "port": "5678",
+            },
+        )
+
+        prometheus_rel_data = self.harness.get_relation_data(
+            prometheus_rel_id, self.harness.model.app.name
+        )
+        scrape_jobs = json.loads(prometheus_rel_data.get("scrape_jobs", "[]"))
+        self.assertEqual(len(scrape_jobs), 2)
+
+        self.harness.remove_relation_unit(target_rel_id_2, "target-app-2/0")
+        scrape_jobs = json.loads(prometheus_rel_data.get("scrape_jobs", "[]"))
+        self.assertEqual(len(scrape_jobs), 1)
+
+        expected_jobs = [
+            {
+                "job_name": "juju_testmodel_1234567_target-app-1_prometheus_scrape",
+                "static_configs": [
+                    {
+                        "targets": ["scrape_target_0:1234"],
+                        "labels": {
+                            "juju_model": "testmodel",
+                            "juju_model_uuid": "1234567890",
+                            "juju_application": "target-app-1",
+                            "juju_unit": "target-app-1/0",
+                            "host": "scrape_target_0",
+                        },
+                    }
+                ],
+            }
+        ]
+        self.assertListEqual(scrape_jobs, expected_jobs)
+
+    def test_alert_rules_removal_differentiates_between_applications(self):
+        prometheus_rel_id = self.harness.add_relation(PROMETHEUS_RELATION, "prometheus")
+        self.harness.add_relation_unit(prometheus_rel_id, "prometheus/0")
+
+        alert_rules_rel_id_1 = self.harness.add_relation("prometheus-rules", "rules-app-1")
+        self.harness.add_relation_unit(alert_rules_rel_id_1, "rules-app-1/0")
+        self.harness.update_relation_data(
+            alert_rules_rel_id_1,
+            "rules-app-1/0",
+            {"groups": ALERT_RULE_1},
+        )
+
+        alert_rules_rel_id_2 = self.harness.add_relation("prometheus-rules", "rules-app-2")
+        self.harness.add_relation_unit(alert_rules_rel_id_2, "rules-app-2/0")
+        self.harness.update_relation_data(
+            alert_rules_rel_id_2,
+            "rules-app-2/0",
+            {"groups": ALERT_RULE_2},
+        )
+
+        prometheus_rel_data = self.harness.get_relation_data(
+            prometheus_rel_id, self.harness.model.app.name
+        )
+
+        alert_rules = json.loads(prometheus_rel_data.get("alert_rules", "{}"))
+        groups = alert_rules.get("groups", [])
+        self.assertEqual(len(groups), 2)
+
+        self.harness.remove_relation_unit(alert_rules_rel_id_2, "rules-app-2/0")
+        alert_rules = json.loads(prometheus_rel_data.get("alert_rules", "{}"))
+        groups = alert_rules.get("groups", [])
+        self.assertEqual(len(groups), 1)
+
+        expected_groups = [
+            {
+                "name": "juju_testmodel_1234567_rules-app-1_alert_rules",
+                "rules": [
+                    {
+                        "alert": "CPU_Usage",
+                        "expr": 'cpu_usage_idle{is_container!="True", group="promoagents-juju"} < 10',
+                        "for": "5m",
+                        "labels": {
+                            "override_group_by": "host",
+                            "severity": "page",
+                            "cloud": "juju",
+                            "juju_model": "testmodel",
+                            "juju_model_uuid": "1234567",
+                            "juju_application": "rules-app-1",
+                            "juju_unit": "rules-app-1/0",
+                        },
+                        "annotations": {
+                            "description": "Host {{ $labels.host }} has had <  10% idle cpu for the last 5m\n",
+                            "summary": "Host {{ $labels.host }} CPU free is less than 10%",
+                        },
+                    }
+                ],
+            },
+        ]
+
+        self.assertListEqual(groups, expected_groups)
+
+    def test_removing_scrape_jobs_differentiates_between_units(self):
+        prometheus_rel_id = self.harness.add_relation(PROMETHEUS_RELATION, "prometheus")
+        self.harness.add_relation_unit(prometheus_rel_id, "prometheus/0")
+
+        target_rel_id = self.harness.add_relation("prometheus-target", "target-app")
+        self.harness.add_relation_unit(target_rel_id, "target-app/0")
+        self.harness.update_relation_data(
+            target_rel_id,
+            "target-app/0",
+            {
+                "hostname": "scrape_target_0",
+                "port": "1234",
+            },
+        )
+
+        self.harness.add_relation_unit(target_rel_id, "target-app/1")
+        self.harness.update_relation_data(
+            target_rel_id,
+            "target-app/1",
+            {
+                "hostname": "scrape_target_1",
+                "port": "5678",
+            },
+        )
+
+        prometheus_rel_data = self.harness.get_relation_data(
+            prometheus_rel_id, self.harness.model.app.name
+        )
+        scrape_jobs = json.loads(prometheus_rel_data.get("scrape_jobs", "[]"))
+
+        self.assertEqual(len(scrape_jobs), 1)
+        self.assertEqual(len(scrape_jobs[0].get("static_configs")), 2)
+
+        self.harness.remove_relation_unit(target_rel_id, "target-app/1")
+        scrape_jobs = json.loads(prometheus_rel_data.get("scrape_jobs", "[]"))
+
+        self.assertEqual(len(scrape_jobs), 1)
+        self.assertEqual(len(scrape_jobs[0].get("static_configs")), 1)
+
+        expected_jobs = [
+            {
+                "job_name": "juju_testmodel_1234567_target-app_prometheus_scrape",
+                "static_configs": [
+                    {
+                        "targets": ["scrape_target_0:1234"],
+                        "labels": {
+                            "juju_model": "testmodel",
+                            "juju_model_uuid": "1234567890",
+                            "juju_application": "target-app",
+                            "juju_unit": "target-app/0",
+                            "host": "scrape_target_0",
+                        },
+                    }
+                ],
+            }
+        ]
+        self.assertListEqual(scrape_jobs, expected_jobs)
+
+    def test_removing_alert_rules_differentiates_between_units(self):
+        prometheus_rel_id = self.harness.add_relation(PROMETHEUS_RELATION, "prometheus")
+        self.harness.add_relation_unit(prometheus_rel_id, "prometheus/0")
+
+        alert_rules_rel_id = self.harness.add_relation("prometheus-rules", "rules-app")
+        self.harness.add_relation_unit(alert_rules_rel_id, "rules-app/0")
+        self.harness.update_relation_data(
+            alert_rules_rel_id,
+            "rules-app/0",
+            {"groups": ALERT_RULE_1},
+        )
+
+        self.harness.add_relation_unit(alert_rules_rel_id, "rules-app/1")
+        self.harness.update_relation_data(
+            alert_rules_rel_id,
+            "rules-app/1",
+            {"groups": ALERT_RULE_2},
+        )
+
+        prometheus_rel_data = self.harness.get_relation_data(
+            prometheus_rel_id, self.harness.model.app.name
+        )
+
+        alert_rules = json.loads(prometheus_rel_data.get("alert_rules", "{}"))
+        groups = alert_rules.get("groups", [])
+        self.assertEqual(len(groups), 1)
+
+        self.harness.remove_relation_unit(alert_rules_rel_id, "rules-app/1")
+
+        alert_rules = json.loads(prometheus_rel_data.get("alert_rules", "{}"))
+        groups = alert_rules.get("groups", [])
+        self.assertEqual(len(groups), 1)
+
+        expected_groups = [
+            {
+                "name": "juju_testmodel_1234567_rules-app_alert_rules",
+                "rules": [
+                    {
+                        "alert": "CPU_Usage",
+                        "expr": 'cpu_usage_idle{is_container!="True", group="promoagents-juju"} < 10',
+                        "for": "5m",
+                        "labels": {
+                            "override_group_by": "host",
+                            "severity": "page",
+                            "cloud": "juju",
+                            "juju_model": "testmodel",
+                            "juju_model_uuid": "1234567",
+                            "juju_application": "rules-app",
+                            "juju_unit": "rules-app/0",
+                        },
+                        "annotations": {
+                            "description": "Host {{ $labels.host }} has had <  10% idle cpu for the last 5m\n",
+                            "summary": "Host {{ $labels.host }} CPU free is less than 10%",
+                        },
+                    }
+                ],
+            },
+        ]
+
+        self.assertListEqual(groups, expected_groups)

--- a/tests/test_endpoint_aggregator.py
+++ b/tests/test_endpoint_aggregator.py
@@ -4,11 +4,9 @@
 import json
 import unittest
 
+from charms.prometheus_k8s.v0.prometheus import MetricsEndpointAggregator
 from ops.charm import CharmBase
 from ops.testing import Harness
-
-from charms.prometheus_k8s.v0.prometheus import MetricsEndpointAggregator
-
 
 PROMETHEUS_RELATION = "metrics-endpoint"
 SCRAPE_TARGET_RELATION = "prometheus-target"

--- a/tests/test_endpoint_consumer.py
+++ b/tests/test_endpoint_consumer.py
@@ -343,7 +343,7 @@ class TestEndpointConsumer(unittest.TestCase):
         for label_name, label_value in labels.items():
             self.assertNotEqual(label_value, bad_labels[label_name])
 
-    def test_provider_returns_alerts_indexed_by_relation_id(self):
+    def test_provider_returns_alerts_indexed_by_group_name(self):
         self.assertEqual(self.harness.charm._stored.num_events, 0)
 
         rel_id = self.harness.add_relation(RELATION_NAME, "consumer")
@@ -360,15 +360,9 @@ class TestEndpointConsumer(unittest.TestCase):
 
         alerts = self.harness.charm.prometheus_provider.alerts()
         self.assertEqual(len(alerts), 1)
-        self.assertIn(rel_id, alerts.keys())
-
-        alert = alerts[rel_id]
-        self.assertIn("groups", alert)
-        self.assertIn("model", alert)
-        self.assertIn("model_uuid", alert)
-        self.assertIn("application", alert)
-
-        self.assertListEqual(alert["groups"], ALERT_RULES["groups"])
+        for name, alert_group in alerts.items():
+            group = next((group for group in ALERT_RULES["groups"] if group["name"] == name), None)
+            self.assertDictEqual(alert_group, group)
 
     def test_provider_logs_an_error_on_missing_alerting_data(self):
         self.assertEqual(self.harness.charm._stored.num_events, 0)


### PR DESCRIPTION
This pull request provides a new `MetricsEndpointAggregator` object which is at present primarily meant to support integration with OpenStack charms. Future pull requests may enhance and if necessary refactor this object to support the "Scrape Configuration" charm.