### PR TITLE
Rename prometheus library same as interface name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ validates all configurations options when provided before generating
 its config file.
 
 The `PrometheusCharm` object interacts with its scrape targets using a
-[charm library](lib/charms/prometheus_k8s/v1/prometheus.py).
+[charm library](lib/charms/prometheus_k8s/v0/prometheus_scrape.py).
 
 ### Library Details
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ juju deploy prometheus-k8s
 By default the Prometheus Operator monitors itself, but it also
 accepts additional scrape targets over Juju relations with charms that
 support the `prometheus_scrape` interface and preferably use the
-Prometheus charm library. This [charm library](lib/charms/prometheus_k8s/v1/prometheus.py)
+Prometheus charm library. This [charm library](lib/charms/prometheus_k8s/v0/prometheus_scrape.py)
 provides an `add_endpoint()` method that creates additional scrape
 targets. Each scrape target is expected to expose a `/metrics` HTTP
 path that exposes its metrics in a Prometheus compatible format. For

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -34,7 +34,7 @@ example, assuming your charm exposes a metrics endpoint over a
 relation named "metrics_endpoint", you may instantiate
 `MetricsEndpointProvider` as follows
 
-    from charms.prometheus_k8s.v0.prometheus import MetricsEndpointProvider
+    from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -182,7 +182,7 @@ with three two pieces of information
 For example a Prometheus charm may instantiate the
 `MetricsEndpointConsumer` in its constructor as follows
 
-    from charms.prometheus_k8s.v0.prometheus import MetricsEndpointConsumer
+    from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointConsumer
 
     def __init__(self, *args):
         super().__init__(*args)

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,7 +12,7 @@ import yaml
 from charms.alertmanager_k8s.v0.alertmanager import AlertmanagerConsumer
 from charms.grafana_k8s.v0.grafana_source import GrafanaSourceConsumer
 from charms.nginx_ingress_integrator.v0.ingress import IngressRequires
-from charms.prometheus_k8s.v0.prometheus import MetricsEndpointConsumer
+from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointConsumer
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.main import main

--- a/tests/test_endpoint_aggregator.py
+++ b/tests/test_endpoint_aggregator.py
@@ -4,7 +4,7 @@
 import json
 import unittest
 
-from charms.prometheus_k8s.v0.prometheus import MetricsEndpointAggregator
+from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointAggregator
 from ops.charm import CharmBase
 from ops.testing import Harness
 

--- a/tests/test_endpoint_consumer.py
+++ b/tests/test_endpoint_consumer.py
@@ -4,7 +4,7 @@
 import json
 import unittest
 
-from charms.prometheus_k8s.v0.prometheus import MetricsEndpointConsumer
+from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointConsumer
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.testing import Harness

--- a/tests/test_endpoint_provider.py
+++ b/tests/test_endpoint_provider.py
@@ -6,7 +6,7 @@ import re
 import unittest
 from unittest.mock import patch
 
-from charms.prometheus_k8s.v0.prometheus import MetricsEndpointProvider
+from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.testing import Harness


### PR DESCRIPTION
A recent convention has been adopted to ensure charm library
names have the same name as the interface the service. This
commit ensures that Prometheus charm library confirms with
this convention.