### PR TITLE
Refactor rules path workflow and unit tests

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1023,14 +1023,14 @@ class MetricsEndpointProvider(Object):
         self._charm = charm
         self._alert_rules_path = alert_rules_path
         self._relation_name = relation_name
-        # Sanitize job configurations to the supported subset of parameters
+        # sanitize job configurations to the supported subset of parameters
         self._jobs = [_sanitize_scrape_configuration(job) for job in jobs]
 
         events = self._charm.on[self._relation_name]
         self.framework.observe(events.relation_joined, self._set_scrape_job_spec)
         self.framework.observe(events.relation_changed, self._set_scrape_job_spec)
 
-        # DIRTY FIX: Set the ip address when the containers start, as a workaround
+        # dirty fix: set the ip address when the containers start, as a workaround
         # for not being able to lookup the pod ip
         for container_name in charm.unit.containers:
             self.framework.observe(
@@ -1041,13 +1041,13 @@ class MetricsEndpointProvider(Object):
         self.framework.observe(self._charm.on.upgrade_charm, self._set_scrape_job_spec)
 
     def _set_scrape_job_spec(self, event):
-        """Ensure scrape target information is made available to Prometheus.
+        """Ensure scrape target information is made available to prometheus.
 
-        When a metrics provider charm is related to a Prometheus charm, the
+        when a metrics provider charm is related to a prometheus charm, the
         metrics provider sets metadata related to its own scrape
-        configutation.  This metadata is set using Juju application
-        data.  In addition each of the consumer units also sets its own
-        host address in Juju unit relation data.
+        configutation.  this metadata is set using juju application
+        data.  in addition each of the consumer units also sets its own
+        host address in juju unit relation data.
         """
         self._set_unit_ip(event)
 
@@ -1066,10 +1066,10 @@ class MetricsEndpointProvider(Object):
     def _set_unit_ip(self, _: EventBase):
         """Set unit host address.
 
-        Each time a metrics provider charm container is restarted it updates its own
-        host address in the unit relation data for the Prometheus charm.
+        each time a metrics provider charm container is restarted it updates its own
+        host address in the unit relation data for the prometheus charm.
 
-        The only argument specified is an event and it ignored. This is for expediency
+        the only argument specified is an event and it ignored. this is for expediency
         to be able to use this method as an event handler, although no access to the
         event is actually needed.
         """
@@ -1082,10 +1082,10 @@ class MetricsEndpointProvider(Object):
         """Insert juju topology labels into an alert rule.
 
         Args:
-            rule: a dictionary representing a Prometheus alert rule.
+            rule: a dictionary representing a prometheus alert rule.
 
         Returns:
-            a dictionary representing Prometheus alert rule with Juju
+            a dictionary representing prometheus alert rule with juju
             topology labels.
         """
         metadata = self._scrape_metadata
@@ -1097,13 +1097,13 @@ class MetricsEndpointProvider(Object):
         return rule
 
     def _label_alert_expression(self, rule) -> dict:
-        """Insert juju topology filters into a Prometheus alert rule.
+        """Insert juju topology filters into a prometheus alert rule.
 
         Args:
-            rule: a dictionary representing a Prometheus alert rule.
+            rule: a dictionary representing a prometheus alert rule.
 
         Returns:
-            a dictionary representing a Prometheus alert rule that filters based
+            a dictionary representing a prometheus alert rule that filters based
             on juju topology.
         """
         metadata = self._scrape_metadata
@@ -1124,11 +1124,11 @@ class MetricsEndpointProvider(Object):
         """Load alert rules from rule files.
 
         All rules from files for a consumer charm are loaded into a single
-        group. The generated name of this group includes Juju topology
+        group. the generated name of this group includes juju topology
         prefixes.
 
         Returns:
-            a list of Prometheus alert rule groups.
+            a list of prometheus alert rule groups.
         """
         alerts = []
         for path in Path(self._alert_rules_path).glob("*.rule"):

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1022,7 +1022,7 @@ class MetricsEndpointProvider(Object):
         super().__init__(charm, relation_name)
 
         self._charm = charm
-        self._ALERT_RULES_PATH = alert_rules_path
+        self._alert_rules_path = alert_rules_path
         self._relation_name = relation_name
         # Sanitize job configurations to the supported subset of parameters
         self._jobs = [_sanitize_scrape_configuration(job) for job in jobs]
@@ -1132,7 +1132,7 @@ class MetricsEndpointProvider(Object):
             a list of Prometheus alert rule groups.
         """
         alerts = []
-        for path in Path(self._ALERT_RULES_PATH).glob("*.rule"):
+        for path in Path(self._alert_rules_path).glob("*.rule"):
             if not path.is_file():
                 continue
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1063,7 +1063,7 @@ class MetricsEndpointProvider(Object):
                     {"groups": alert_groups}
                 )
 
-    def _set_unit_ip(self, _: EventBase):
+    def _set_unit_ip(self, _):
         """Set unit host address.
 
         each time a metrics provider charm container is restarted it updates its own

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1009,15 +1009,14 @@ class MetricsEndpointProvider(Object):
             charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.provides
         )
 
-        if alert_rules_path:
-            try:
-                alert_rules_path = _resolve_dir_against_charm_path(charm, alert_rules_path)
-            except InvalidAlertRuleFolderPathError as e:
-                logger.warning(
-                    "Invalid Prometheus alert rules folder at %s: %s",
-                    e.alert_rules_absolute_path,
-                    e.message,
-                )
+        try:
+            alert_rules_path = _resolve_dir_against_charm_path(charm, alert_rules_path)
+        except InvalidAlertRuleFolderPathError as e:
+            logger.warning(
+                "Invalid Prometheus alert rules folder at %s: %s",
+                e.alert_rules_absolute_path,
+                e.message,
+            )
 
         super().__init__(charm, relation_name)
 

--- a/tests/test_charm.py
+++ b/tests/test_charm.py
@@ -10,7 +10,7 @@ from ops.testing import Harness
 
 from charm import PrometheusCharm
 
-MINIMAL_CONFIG = {"prometheus-image-path": "prom/prometheus"}
+MINIMAL_CONFIG = {}
 
 SAMPLE_ALERTING_CONFIG = {
     "alertmanagers": [{"static_configs": [{"targets": ["192.168.0.1:9093"]}]}]

--- a/tests/test_endpoint_provider.py
+++ b/tests/test_endpoint_provider.py
@@ -18,15 +18,6 @@ from ops.framework import StoredState
 from ops.testing import Harness
 
 RELATION_NAME = "metrics-endpoint"
-CONSUMER_SERVICE = "prometheus_tester"
-CONSUMER_META = f"""
-name: consumer-tester
-containers:
-  prometheus-tester:
-requires:
-  {RELATION_NAME}:
-    interface: prometheus_scrape
-"""
 PROVIDER_META = f"""
 name: consumer-tester
 containers:

--- a/tests/test_endpoint_provider.py
+++ b/tests/test_endpoint_provider.py
@@ -261,7 +261,7 @@ class TestBadConsumers(unittest.TestCase):
 
     @patch("ops.testing._TestingModelBackend.network_get")
     def test_a_bad_alert_expression_logs_an_error(self, _):
-        self.harness.charm.provider._ALERT_RULES_PATH = "./tests/bad_alert_expressions"
+        self.harness.charm.provider._alert_rules_path = "./tests/bad_alert_expressions"
 
         with self.assertLogs(level="ERROR") as logger:
             rel_id = self.harness.add_relation(RELATION_NAME, "provider")
@@ -272,7 +272,7 @@ class TestBadConsumers(unittest.TestCase):
 
     @patch("ops.testing._TestingModelBackend.network_get")
     def test_a_bad_alert_rules_logs_an_error(self, _):
-        self.harness.charm.provider._ALERT_RULES_PATH = "./tests/bad_alert_rules"
+        self.harness.charm.provider._alert_rules_path = "./tests/bad_alert_rules"
 
         with self.assertLogs(level="ERROR") as logger:
             rel_id = self.harness.add_relation(RELATION_NAME, "provider")

--- a/tests/test_endpoint_provider.py
+++ b/tests/test_endpoint_provider.py
@@ -69,21 +69,8 @@ class EndpointProviderCharm(CharmBase):
         super().__init__(*args)
 
         self.provider = MetricsEndpointProvider(
-            self,
-            RELATION_NAME,
-            jobs=JOBS,
+            self, jobs=JOBS, alert_rules_path="./tests/prometheus_alert_rules"
         )
-        self.provider._ALERT_RULES_PATH = "./tests/prometheus_alert_rules"
-
-
-class EndpointProviderDefaultCharm(CharmBase):
-    _stored = StoredState()
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args)
-
-        self.provider = MetricsEndpointProvider(self, jobs=JOBS)
-        self.provider._ALERT_RULES_PATH = "./tests/prometheus_alert_rules"
 
 
 class TestEndpointProvider(unittest.TestCase):
@@ -96,7 +83,7 @@ class TestEndpointProvider(unittest.TestCase):
     def test_provider_default_scrape_relations_not_in_meta(self):
         """Tests that the Provider raises exception when no promethes_scrape in meta."""
         harness = Harness(
-            EndpointProviderDefaultCharm,
+            EndpointProviderCharm,
             # No provider relation with `prometheus_scrape` as interface
             meta="""
                 name: consumer-tester
@@ -114,7 +101,7 @@ class TestEndpointProvider(unittest.TestCase):
     def test_provider_default_scrape_relation_wrong_interface(self):
         """Tests that Provider raises exception if the default relation has the wrong interface."""
         harness = Harness(
-            EndpointProviderDefaultCharm,
+            EndpointProviderCharm,
             # No provider relation with `prometheus_scrape` as interface
             meta="""
                 name: consumer-tester
@@ -132,7 +119,7 @@ class TestEndpointProvider(unittest.TestCase):
     def test_provider_default_scrape_relation_wrong_role(self):
         """Tests that Provider raises exception if the default relation has the wrong role."""
         harness = Harness(
-            EndpointProviderDefaultCharm,
+            EndpointProviderCharm,
             # No provider relation with `prometheus_scrape` as interface
             meta="""
                 name: consumer-tester
@@ -306,8 +293,9 @@ class EndpointProviderOddAlertRulesFolderCharm(CharmBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args)
 
-        self.provider = MetricsEndpointProvider(self, jobs=JOBS)
-        self.provider._ALERT_RULES_PATH = "./tests/non_standard_prometheus_alert_rules"
+        self.provider = MetricsEndpointProvider(
+            self, jobs=JOBS, alert_rules_path="./tests/non_standard_prometheus_alert_rules"
+        )
 
 
 class TestEndpointProviderAlertRules(unittest.TestCase):

--- a/tests/test_endpoint_provider.py
+++ b/tests/test_endpoint_provider.py
@@ -19,7 +19,7 @@ from ops.testing import Harness
 
 RELATION_NAME = "metrics-endpoint"
 PROVIDER_META = f"""
-name: consumer-tester
+name: provider-tester
 containers:
   prometheus-tester:
 provides:
@@ -77,7 +77,7 @@ class TestEndpointProvider(unittest.TestCase):
             EndpointProviderCharm,
             # No provider relation with `prometheus_scrape` as interface
             meta="""
-                name: consumer-tester
+                name: provider-tester
                 containers:
                     prometheus:
                         resource: prometheus-image
@@ -95,7 +95,7 @@ class TestEndpointProvider(unittest.TestCase):
             EndpointProviderCharm,
             # No provider relation with `prometheus_scrape` as interface
             meta="""
-                name: consumer-tester
+                name: provider-tester
                 containers:
                     prometheus:
                         resource: prometheus-image
@@ -113,7 +113,7 @@ class TestEndpointProvider(unittest.TestCase):
             EndpointProviderCharm,
             # No provider relation with `prometheus_scrape` as interface
             meta="""
-                name: consumer-tester
+                name: provider-tester
                 containers:
                     prometheus:
                         resource: prometheus-image
@@ -126,7 +126,7 @@ class TestEndpointProvider(unittest.TestCase):
         self.assertRaises(RelationRoleMismatchError, harness.begin)
 
     @patch("ops.testing._TestingModelBackend.network_get")
-    def test_consumer_sets_scrape_metadata(self, _):
+    def test_provider_sets_scrape_metadata(self, _):
         rel_id = self.harness.add_relation(RELATION_NAME, "provider")
         self.harness.add_relation_unit(rel_id, "provider/0")
         data = self.harness.get_relation_data(rel_id, self.harness.model.app.name)
@@ -137,7 +137,7 @@ class TestEndpointProvider(unittest.TestCase):
         self.assertIn("application", scrape_metadata)
 
     @patch("ops.testing._TestingModelBackend.network_get")
-    def test_consumer_unit_sets_bind_address_on_pebble_ready(self, mock_net_get):
+    def test_provider_unit_sets_bind_address_on_pebble_ready(self, mock_net_get):
         bind_address = "192.0.8.2"
         fake_network = {
             "bind-addresses": [
@@ -155,7 +155,7 @@ class TestEndpointProvider(unittest.TestCase):
         self.assertEqual(data["prometheus_scrape_host"], bind_address)
 
     @patch("ops.testing._TestingModelBackend.network_get")
-    def test_consumer_unit_sets_bind_address_on_relation_joined(self, mock_net_get):
+    def test_provider_unit_sets_bind_address_on_relation_joined(self, mock_net_get):
         bind_address = "192.0.8.2"
         fake_network = {
             "bind-addresses": [
@@ -173,7 +173,7 @@ class TestEndpointProvider(unittest.TestCase):
         self.assertEqual(data["prometheus_scrape_host"], bind_address)
 
     @patch("ops.testing._TestingModelBackend.network_get")
-    def test_consumer_supports_multiple_jobs(self, _):
+    def test_provider_supports_multiple_jobs(self, _):
         rel_id = self.harness.add_relation(RELATION_NAME, "provider")
         self.harness.add_relation_unit(rel_id, "provider/0")
         data = self.harness.get_relation_data(rel_id, self.harness.model.app.name)
@@ -185,7 +185,7 @@ class TestEndpointProvider(unittest.TestCase):
         self.assertListEqual(names, job_names)
 
     @patch("ops.testing._TestingModelBackend.network_get")
-    def test_consumer_sanitizes_jobs(self, _):
+    def test_provider_sanitizes_jobs(self, _):
         rel_id = self.harness.add_relation(RELATION_NAME, "provider")
         self.harness.add_relation_unit(rel_id, "provider/0")
         data = self.harness.get_relation_data(rel_id, self.harness.model.app.name)
@@ -230,7 +230,7 @@ class TestEndpointProvider(unittest.TestCase):
                 self.assertIn("juju_application", labels)
 
 
-class TestBadConsumers(unittest.TestCase):
+class TestBadProviders(unittest.TestCase):
     def setUp(self):
         self.harness = Harness(EndpointProviderCharm, meta=PROVIDER_META)
         self.addCleanup(self.harness.cleanup)


### PR DESCRIPTION
The pull requests refactors the following

1. The alert rules path workflow had a minor bug as a result of which alert rules were not being set.
2. Unit tests were inject alert rules path directly into the Provider object rather than using the constructor argument. As a result the bug in alert rules path workflow was not picked up.
3. Due to [limitations](https://github.com/canonical/operator/issues/643) in current Operator Framework it is necessary to determine the top level charm directory differently between deployed charms and running unit tests.
4. A previous commit interchanged roles of provider and consumer but did not interchange names in unit test names. This PR fixes the issue.
5. Prior code changes removed the prometheus-image configuration option but this was left over in the unit tests and has now been removed.
6. Other minor cosmetic refactors.