### PR TITLE
fix in-place dict update

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -560,7 +560,9 @@ def load_alert_rule_from_file(path: Path, topology: JujuTopology) -> Optional[di
             return None
         else:
             # add "juju_" topology labels
-            rule.get("labels", {}).update(topology.as_dict_with_promql_labels())
+            if "labels" not in rule:
+                rule["labels"] = {}
+            rule["labels"].update(topology.as_dict_with_promql_labels())
 
             if "expr" not in rule:
                 logger.error("Invalid alert rule %s: missing an 'expr' property.", path.name)

--- a/tests/unit/prometheus_alert_rules/cpu_overuse_no_labels.rule
+++ b/tests/unit/prometheus_alert_rules/cpu_overuse_no_labels.rule
@@ -1,0 +1,6 @@
+alert: CPUOverUse_no_labels
+expr: process_cpu_seconds_total{%%juju_topology%%} > 0.12
+for: 0m
+annotations:
+  summary: "Instance {{ $labels.instance }} CPU over use"
+  description: "{{ $labels.instance }} of job {{ $labels.job }} has used too much CPU."

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -385,8 +385,13 @@ class TestLoadAlertRulesFromDir(unittest.TestCase):
     def test_nested_rules_not_read_by_default(self):
         group = self.rule_groups[0]
         rules = group["rules"]
-        # TODO consider using in-memory filesystem instead of actual disk files
         self.assertTrue(not (any(rule["alert"] == "CPUOverUseNested" for rule in rules)))
+
+    def test_all_alerts_have_labels(self):
+        group = self.rule_groups[0]
+        rules = group["rules"]
+        self.assertTrue(any(rule["alert"] == "CPUOverUse_no_labels" for rule in rules))
+        self.assertTrue(all("labels" in rule for rule in rules))
 
 
 class TestLoadAlertRulesFromDirNested(unittest.TestCase):


### PR DESCRIPTION
This PR fixes a bug introduced in #149:
`rule.get("labels", {}).update(topology.as_dict_with_promql_labels())` won't update `rule` if `"labels"` is not in there - the new empty dict is not referenced by `rule`.

```python
>>> d = {}; d.get("labels", {}).update(k="v"); print(d)
{}
>>> if "labels" not in d:
...     d["labels"] = {}
... 
>>> d["labels"].update(k="v"); print(d)
{'labels': {'k': 'v'}}
>>> 
```