### PR TITLE
use python-libjuju from pypi

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,8 @@ commands =
 description = Run integration tests
 deps =
     aiohttp
-    git+https://github.com/juju/python-libjuju.git
+    #git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
 commands =
@@ -81,7 +82,8 @@ lma_bundle_dir = {envtmpdir}/lma-light-bundle
 deps =
     # deps from lma-bundle - these are needed here because will be running pytest on lma-bundle
     jinja2
-    git+https://github.com/juju/python-libjuju.git
+    #git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
 allowlist_externals =


### PR DESCRIPTION
Recent changes to the main branch of python-libjuju [introduced a regression](https://github.com/canonical/prometheus-operator/runs/4148835885?check_suite_focus=true).

```
INFO     pytest_operator.plugin:plugin.py:235 Adding model github-pr-8b3ef:test-charm-meps
ERROR    asyncio:base_events.py:1707 Task exception was never retrieved
future: <Task finished name='Task-30' coro=<Connection._pinger() done, defined at /home/runner/work/prometheus-operator/prometheus-operator/.tox/integration/lib/python3.8/site-packages/juju/client/connection.py:502> exception=Exception('No facade Pinger in facades {}')>
Traceback (most recent call last):
  File "/home/runner/work/prometheus-operator/prometheus-operator/.tox/integration/lib/python3.8/site-packages/juju/client/connection.py", line 516, in _pinger
    pinger_facade = client.PingerFacade.from_connection(self)
  File "/home/runner/work/prometheus-operator/prometheus-operator/.tox/integration/lib/python3.8/site-packages/juju/client/_client.py", line 66, in from_connection
    raise Exception('No facade {} in facades {}'.format(facade_name,
Exception: No facade Pinger in facades {}
```

Switch to using python-libjuju from pypi.