### PR TITLE
add support for dual rules format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ The Prometheus charm library facilitates two things
    alert rules and related metadata to the Prometheus charm.
 2. For metrics consumers (the Prometheus charm) to assimilate information
    provided by the scrape targets, so that it may be used to configure
-   Promtheus.
+   Prometheus.
 
 The Prometheus charm library exposes a consumer and provider object -
 `MetricsEndpointConsumer` and `MetricsEndpointProvider` along with the custom
@@ -125,18 +125,10 @@ Prometheus configuration using information provided by the `jobs()`
 and `alerts()` methods of the `MetricsEndpointConsumer`.
 
 The `jobs()` method gathers a list of scrape jobs from all related
-scrape target charms. In doing so it invokes the `_static_scrape_config()`
-method for each such relation. `_static_scrape_config()` generates a
-unique job name for each job, sanitizes the job and associates Juju
-topology labels with it. Labeling of Juju topology is done by
-`_labeled_static_job_config()`. However the labeling differs for
-scrape targets whose host address was automatically gathered and those
-addresses were explicitly specified. Hence three separate
-functions are required for labeling `_set_juju_labels()` for labels
-common to both but `_labeled_unitless_config()` and
-`_labeled_unit_config()` for the differing labels. The list of
-automatically gathered host address is provided by
-`_relation_hosts()`.
+scrape target charms, generating a unique job name for each job and associates
+Juju topology labels with it. The labeling differs for scrape targets whose
+host address was automatically gathered and for addresses that were explicitly
+specified.
 
 The `MetricsEndpointProvider` is responsible for forwarding scrape
 configuration, scrape target addresses, scrape metadata and alert
@@ -145,12 +137,7 @@ alert rules have Juju topology labels and filters injected into
 them. The `_set_unit_ip()` methods forwards scrape target host
 addresses using unit relation data. The `_set_scrape_metadata()`
 method forwards all the other information using application relation
-data. The list of scrape jobs is gathered by the `_scrape_jobs()`
-method and Juju topology information is constructed using the
-`_scrape_metadata()` method. Finally `_labeled_alert_groups()` loads
-alert rules from files and ensures they include Juju topology labels
-and filters respectively by invoking `_label_alert_topology()` and
-`_label_alert_expression()`.
+data.
 
 ### Charm Details
 

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -679,6 +679,7 @@ class AlertRules:
         #  - name, from juju topology
         #  - suffix, from the relative path of the rule file;
         group_name_parts = [self.topology.identifier, rel_path, group_name, "alerts"]
+        # filter to remove empty strings
         return "_".join(filter(None, group_name_parts))
 
     def _from_dir(self, dir_path: Path, recursive: bool) -> List[dict]:
@@ -706,7 +707,7 @@ class AlertRules:
                 logger.debug("Reading alert rule from %s", file_path)
                 alert_groups.extend(alert_groups_from_file)
 
-        return alert_groups if alert_groups else []
+        return alert_groups
 
     def add_path(self, path: str, *, recursive: bool = False):
         """Add rules from a dir path.
@@ -719,7 +720,7 @@ class AlertRules:
             recursive: whether to read files recursively or not (no impact if `path` is a file).
 
         Raises:
-            NotADirectoryError: if the provided path is invalid.
+            InvalidAlertRulePathError: if the provided path is invalid.
         """
         path = Path(path)  # type: Path
         if path.is_dir():

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -241,10 +241,15 @@ Prometheus charm.  Alert rules are automatically gathered by `MetricsEndpointPro
 charms when using this library, from a directory conventionally named
 `prometheus_alert_rules`. This directory must reside at the top level
 in the `src` folder of the consumer charm. Each file in this directory
-is assumed to be a single alert rule in YAML format. The file name must
-have the `.rule` extension. The format of this alert rule conforms to the
-[Prometheus docs](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/).
-An example of the contents of one such file is shown below.
+is assumed to be in one of two formats:
+- the official prometheus alert rule format, conforming to the
+[Prometheus docs](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/)
+- a custom format, which is a simplified subset of the official format, comprising a single alert
+rule per file, in the same YAML format.
+
+The file name must have the `.rule` extension.
+
+An example of the contents of one such file in the custom format is shown below.
 
 ```
 alert: HighRequestLatency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,7 @@ docstring-convention = "google"
 copyright-check = "True"
 copyright-author = "Canonical Ltd."
 copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+
+[tool.mypy]
+pretty = true
+allow_redefinition = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+git://github.com/canonical/operator
+git+git://github.com/canonical/operator#egg=ops
 pyaml
 requests
 lightkube >= 0.8.1

--- a/src/charm.py
+++ b/src/charm.py
@@ -131,10 +131,10 @@ class PrometheusCharm(CharmBase):
         """
         container.remove_path(RULES_DIR, recursive=True)
 
-        for group_name, group in self.metrics_consumer.alerts().items():
-            filename = "juju_" + group_name + ".rules"
+        for topology_identifier, rules_file in self.metrics_consumer.alerts().items():
+            filename = "juju_" + topology_identifier + ".rules"
             path = os.path.join(RULES_DIR, filename)
-            rules = yaml.dump({"groups": [group]})
+            rules = yaml.dump(rules_file)
 
             container.push(path, rules, make_dirs=True)
             logger.debug("Updated alert rules file %s", filename)

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,0 +1,34 @@
+# Copyright 2020 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import os
+import tempfile
+from typing import Tuple
+
+
+class Sandbox:
+    """A helper class for creating files in a temporary folder (sandbox)."""
+
+    def __init__(self):
+        self.root = tempfile.mkdtemp()
+
+    def put_file(self, rel_path: str, contents: str):
+        """Write string to file.
+
+        Args:
+            rel_path: path to file, relative to the sandbox root.
+            contents: the data to write to file.
+        """
+        file_path = os.path.join(self.root, rel_path)
+        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+        with open(file_path, "wt") as f:
+            f.write(contents)
+
+    def put_files(self, *args: Tuple[str, str]):
+        """Write strings to files. A vectorized version of `put_file`.
+
+        Args:
+            args: a tuple of path and contents.
+        """
+        for rel_path, contents in args:
+            self.put_file(rel_path, contents)

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -6,7 +6,7 @@ import tempfile
 from typing import Tuple
 
 
-class Sandbox:
+class TempFolderSandbox:
     """A helper class for creating files in a temporary folder (sandbox)."""
 
     def __init__(self):

--- a/tests/unit/prometheus_alert_rules/nested_rules_dir/cpu_overuse.rule
+++ b/tests/unit/prometheus_alert_rules/nested_rules_dir/cpu_overuse.rule
@@ -1,8 +1,0 @@
-alert: CPUOverUseNested
-expr: process_cpu_seconds_total{%%juju_topology%%} > 0.12
-for: 0m
-labels:
-  severity: Low
-annotations:
-  summary: "Instance {{ $labels.instance }} CPU over use"
-  description: "{{ $labels.instance }} of job {{ $labels.job }} has used too much CPU."

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -358,15 +358,16 @@ class TestEndpointConsumer(unittest.TestCase):
             "consumer",
             {
                 "scrape_metadata": json.dumps(SCRAPE_METADATA),
-                "alert_rules": json.dumps(["dummy_topology_identifier", ALERT_RULES]),
+                "alert_rules": json.dumps(ALERT_RULES),
             },
         )
         self.harness.add_relation_unit(rel_id, "consumer/0")
         self.assertEqual(self.harness.charm._stored.num_events, 1)
 
         rules_file = self.harness.charm.prometheus_consumer.alerts()
+        self.maxDiff = None
         alerts = list(rules_file.values())[0]
-        self.assertDictEqual(ALERT_RULES, alerts)
+        self.assertEqual(ALERT_RULES, alerts)
 
     def test_consumer_logs_an_error_on_missing_alerting_data(self):
         self.assertEqual(self.harness.charm._stored.num_events, 0)

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -340,7 +340,6 @@ class TestEndpointConsumer(unittest.TestCase):
             rel_id, "consumer/0", {"prometheus_scrape_host": "1.1.1.1"}
         )
         self.assertEqual(self.harness.charm._stored.num_events, 2)
-
         jobs = self.harness.charm.prometheus_consumer.jobs()
         self.assertEqual(len(jobs), 1)
         self.validate_jobs(jobs)
@@ -365,7 +364,6 @@ class TestEndpointConsumer(unittest.TestCase):
         self.assertEqual(self.harness.charm._stored.num_events, 1)
 
         rules_file = self.harness.charm.prometheus_consumer.alerts()
-        self.maxDiff = None
         alerts = list(rules_file.values())[0]
         self.assertEqual(ALERT_RULES, alerts)
 

--- a/tests/unit/test_endpoint_consumer.py
+++ b/tests/unit/test_endpoint_consumer.py
@@ -349,7 +349,7 @@ class TestEndpointConsumer(unittest.TestCase):
         for label_name, label_value in labels.items():
             self.assertNotEqual(label_value, bad_labels[label_name])
 
-    def test_consumer_returns_alerts_indexed_by_group_name(self):
+    def test_consumer_returns_alerts_rules_file(self):
         self.assertEqual(self.harness.charm._stored.num_events, 0)
 
         rel_id = self.harness.add_relation(RELATION_NAME, "consumer")
@@ -358,17 +358,15 @@ class TestEndpointConsumer(unittest.TestCase):
             "consumer",
             {
                 "scrape_metadata": json.dumps(SCRAPE_METADATA),
-                "alert_rules": json.dumps(ALERT_RULES),
+                "alert_rules": json.dumps(["dummy_topology_identifier", ALERT_RULES]),
             },
         )
         self.harness.add_relation_unit(rel_id, "consumer/0")
         self.assertEqual(self.harness.charm._stored.num_events, 1)
 
-        alerts = self.harness.charm.prometheus_consumer.alerts()
-        self.assertEqual(len(alerts), 1)
-        for name, alert_group in alerts.items():
-            group = next((group for group in ALERT_RULES["groups"] if group["name"] == name), None)
-            self.assertDictEqual(alert_group, group)
+        rules_file = self.harness.charm.prometheus_consumer.alerts()
+        alerts = list(rules_file.values())[0]
+        self.assertDictEqual(ALERT_RULES, alerts)
 
     def test_consumer_logs_an_error_on_missing_alerting_data(self):
         self.assertEqual(self.harness.charm._stored.num_events, 0)

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -332,18 +332,22 @@ class TestAlertRules(unittest.TestCase):
         self.topology = JujuTopology("MyModel", "MyUUID", "MyApp", "MyCharm")
 
     def test_non_recursive_is_default(self):
-        rules_file_dict = AlertRules.from_path(
-            os.path.join(self.sandbox.root, "rules", "prom"), topology=self.topology
-        ).as_rules_file_dict()
+        rules_file_dict = (
+            AlertRules(self.topology)
+            .add_from_path(os.path.join(self.sandbox.root, "rules", "prom"))
+            .as_rules_file_dict()
+        )
         self.assertEqual({}, rules_file_dict)
 
     def test_alerts_in_both_formats_are_recursively_aggregated(self):
-        self.maxDiff = None
-        rules_file_dict = AlertRules.from_path(
-            os.path.join(self.sandbox.root, "rules", "prom"),
-            topology=self.topology,
-            recursive=True,
-        ).as_rules_file_dict()
+        rules_file_dict = (
+            AlertRules(self.topology)
+            .add_from_path(
+                os.path.join(self.sandbox.root, "rules", "prom"),
+                recursive=True,
+            )
+            .as_rules_file_dict()
+        )
 
         expected_alert_rule = {
             "alert": "CPUOverUse",

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -3,22 +3,27 @@
 
 import functools
 import json
+import os
 import re
 import unittest
 from unittest.mock import patch
 
+import yaml
 from charms.prometheus_k8s.v0.prometheus_scrape import (
     ALLOWED_KEYS,
+    AlertRules,
     JujuTopology,
     MetricsEndpointProvider,
     RelationInterfaceMismatchError,
     RelationNotFoundError,
     RelationRoleMismatchError,
-    load_alert_rules_from_dir,
 )
+from deepdiff import DeepDiff
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.testing import Harness
+
+from .helpers import Sandbox
 
 RELATION_NAME = "metrics-endpoint"
 PROVIDER_META = f"""
@@ -204,9 +209,9 @@ class TestEndpointProvider(unittest.TestCase):
         self.harness.add_relation_unit(rel_id, "provider/0")
         data = self.harness.get_relation_data(rel_id, self.harness.model.app.name)
         self.assertIn("alert_rules", data)
-        alerts = json.loads(data["alert_rules"])
+        alerts = json.loads(data["alert_rules"])[1]
         self.assertIn("groups", alerts)
-        self.assertEqual(len(alerts["groups"]), 1)
+        self.assertEqual(len(alerts["groups"]), 3)
         group = alerts["groups"][0]
         for rule in group["rules"]:
             self.assertIn("labels", rule)
@@ -221,9 +226,9 @@ class TestEndpointProvider(unittest.TestCase):
         self.harness.add_relation_unit(rel_id, "provider/0")
         data = self.harness.get_relation_data(rel_id, self.harness.model.app.name)
         self.assertIn("alert_rules", data)
-        alerts = json.loads(data["alert_rules"])
+        alerts = json.loads(data["alert_rules"])[1]
         self.assertIn("groups", alerts)
-        self.assertEqual(len(alerts["groups"]), 1)
+        self.assertEqual(len(alerts["groups"]), 3)
         group = alerts["groups"][0]
         for rule in group["rules"]:
             self.assertIn("expr", rule)
@@ -272,9 +277,7 @@ class TestNonStandardProviders(unittest.TestCase):
             self.harness.add_relation_unit(rel_id, "provider/0")
             messages = sorted(logger.output)
             self.assertEqual(len(messages), 1)
-            self.assertIn(
-                "Invalid alert rule missing_expr.rule: missing an 'expr' property", messages[0]
-            )
+            self.assertIn("Invalid rules file: missing_expr.rule", messages[0])
 
     @patch("ops.testing._TestingModelBackend.network_get")
     def test_a_bad_alert_rules_logs_an_error(self, _):
@@ -286,17 +289,6 @@ class TestNonStandardProviders(unittest.TestCase):
             messages = sorted(logger.output)
             self.assertEqual(len(messages), 1)
             self.assertIn("Failed to read alert rules from bad_yaml.rule", messages[0])
-
-    def test_provider_default_scrape_relations_not_in_meta(self):
-        self.setup(alert_rules_path="./tests/unit/non_standard_prometheus_alert_rules")
-
-        alert_groups = self.harness.charm.provider._labeled_alert_groups
-        self.assertTrue(len(alert_groups), 1)
-        alert_group = alert_groups[0]
-        rules = alert_group["rules"]
-        self.assertTrue(len(rules), 1)
-        rule = rules[0]
-        self.assertEqual(rule["alert"], "OddRule")
 
 
 def expression_labels(expr):
@@ -317,94 +309,69 @@ def expression_labels(expr):
         yield labels
 
 
-class TestLoadAlertRulesFromDir(unittest.TestCase):
-
-    # [{'name': 'MyModel_MyUUID_MyApp_alerts',
-    #   'rules': [{'alert': 'CPUOverUse',
-    #              'annotations': {'description': '{{ $labels.instance }} of job {{ '
-    #                                             '$labels.job }} has used too much '
-    #                                             'CPU.',
-    #                              'summary': 'Instance {{ $labels.instance }} CPU '
-    #                                         'over use'},
-    #              'expr': 'process_cpu_seconds_total{juju_model="MyModel", '
-    #                      'juju_model_uuid="MyUUID", juju_application="MyApp"} > '
-    #                      '0.12',
-    #              'for': '0m',
-    #              'labels': {'juju_application': 'MyApp',
-    #                         'juju_model': 'MyModel',
-    #                         'juju_model_uuid': 'MyUUID',
-    #                         'severity': 'Low'}},
-    #             {'alert': 'PrometheusTargetMissing',
-    #              'annotations': {'description': 'A Prometheus target has '
-    #                                             'disappeared. An exporter might be '
-    #                                             'crashed.\n'
-    #                                             '  VALUE = {{ $value }}\n'
-    #                                             '  LABELS = {{ $labels }}',
-    #                              'summary': 'Prometheus target missing (instance '
-    #                                         '{{ $labels.instance }})'},
-    #              'expr': 'up{juju_model="MyModel", juju_model_uuid="MyUUID", '
-    #                      'juju_application="MyApp"} == 0',
-    #              'for': '0m',
-    #              'labels': {'juju_application': 'MyApp',
-    #                         'juju_model': 'MyModel',
-    #                         'juju_model_uuid': 'MyUUID',
-    #                         'severity': 'critical'}}]}]
-
+class TestAlertRules(unittest.TestCase):
     def setUp(self) -> None:
-        self.topology = JujuTopology("MyModel", "MyUUID", "MyApp", "MyCharm")
-        self.rule_groups = load_alert_rules_from_dir(
-            "./tests/unit/prometheus_alert_rules", self.topology
+        free_standing_rule = {
+            "alert": "free_standing",
+            "expr": "avg(some_vector[5m]) > 5",
+        }
+
+        alert_rule = {
+            "alert": "CPUOverUse",
+            "expr": "process_cpu_seconds_total{%%juju_topology%%} > 0.12",
+        }
+        rules_file_dict = {"groups": [{"name": "group1", "rules": [alert_rule]}]}
+
+        self.sandbox = Sandbox()
+        self.sandbox.put_files(
+            ("rules/prom/sub1/lma_rule.rule", yaml.safe_dump(alert_rule)),
+            ("rules/prom/sub1/standard_rule.rule", yaml.safe_dump(rules_file_dict)),
+            ("rules/prom/sub2/free_standing_rule.rule", yaml.safe_dump(free_standing_rule)),
         )
 
-    def test_only_one_group_per_file(self):
-        self.assertEqual(len(self.rule_groups), 1)
-
-    def test_group_name_matches_topology(self):
-        group = self.rule_groups[0]
-        self.assertEqual(group["name"], self.topology.identifier + "_alerts")
-
-    def test_at_least_one_alert_rule_in_group(self):
-        group = self.rule_groups[0]
-        rules = group["rules"]
-        self.assertGreaterEqual(len(rules), 1)
-
-    def test_every_alert_rule_has_expr_property(self):
-        group = self.rule_groups[0]
-        rules = group["rules"]
-        self.assertTrue(all(bool(rule.get("expr")) for rule in rules))
-
-    def test_every_alert_rule_has_topology_labels(self):
-        group = self.rule_groups[0]
-        rules = group["rules"]
-        for rule in rules:
-            with self.subTest(alert=rule["alert"]):
-                self.assertGreaterEqual(
-                    rule["labels"].items(), self.topology.as_dict_with_promql_labels().items()
-                )
-
-    def test_nested_rules_not_read_by_default(self):
-        group = self.rule_groups[0]
-        rules = group["rules"]
-        self.assertTrue(not (any(rule["alert"] == "CPUOverUseNested" for rule in rules)))
-
-    def test_all_alerts_have_labels(self):
-        group = self.rule_groups[0]
-        rules = group["rules"]
-        self.assertTrue(any(rule["alert"] == "CPUOverUse_no_labels" for rule in rules))
-        self.assertTrue(all("labels" in rule for rule in rules))
-
-
-class TestLoadAlertRulesFromDirNested(unittest.TestCase):
-    def setUp(self) -> None:
         self.topology = JujuTopology("MyModel", "MyUUID", "MyApp", "MyCharm")
-        self.rule_groups = load_alert_rules_from_dir(
-            "./tests/unit/prometheus_alert_rules", self.topology, recursive=True
-        )
 
-    def test_at_least_one_group_per_file(self):
-        self.assertGreater(len(self.rule_groups), 1)
+    def test_non_recursive_is_default(self):
+        rules_file_dict = AlertRules.from_path(
+            os.path.join(self.sandbox.root, "rules", "prom"), topology=self.topology
+        ).as_rules_file_dict()
+        self.assertEqual({}, rules_file_dict)
 
-    def test_group_name_prefixed_by_subdir_name(self):
-        expected_group_name = "nested_rules_dir_" + self.topology.identifier + "_alerts"
-        nested = list(filter(lambda group: expected_group_name == group["name"], self.rule_groups))
-        self.assertGreaterEqual(len(nested), 1)
+    def test_alerts_in_both_formats_are_recursively_aggregated(self):
+        self.maxDiff = None
+        rules_file_dict = AlertRules.from_path(
+            os.path.join(self.sandbox.root, "rules", "prom"),
+            topology=self.topology,
+            recursive=True,
+        ).as_rules_file_dict()
+
+        expected_alert_rule = {
+            "alert": "CPUOverUse",
+            "expr": f"process_cpu_seconds_total{{{self.topology.promql_labels}}} > 0.12",
+            "labels": self.topology.as_dict_with_promql_labels(),
+        }
+
+        expected_freestanding_rule = {
+            "alert": "free_standing",
+            "expr": "avg(some_vector[5m]) > 5",
+            "labels": self.topology.as_dict_with_promql_labels(),
+        }
+
+        expected_rules_file = {
+            "groups": [
+                {
+                    "name": f"{self.topology.identifier}_sub1_group1_alerts",
+                    "rules": [expected_alert_rule],
+                },
+                {
+                    "name": f"{self.topology.identifier}_sub1_lma_rule_alerts",
+                    "rules": [expected_alert_rule],
+                },
+                {
+                    "name": f"{self.topology.identifier}_sub2_free_standing_rule_alerts",
+                    "rules": [expected_freestanding_rule],
+                },
+            ]
+        }
+
+        self.assertEqual({}, DeepDiff(expected_rules_file, rules_file_dict, ignore_order=True))

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -333,19 +333,15 @@ class TestAlertRulesWithOneRulePerFile(unittest.TestCase):
         self.topology = JujuTopology("MyModel", "MyUUID", "MyApp", "MyCharm")
 
     def test_non_recursive_is_default(self):
-        rules_file_dict = (
-            AlertRules(self.topology)
-            .add_from_path(os.path.join(self.sandbox.root, "rules", "prom"))
-            .as_dict()
-        )
+        rules = AlertRules(self.topology)
+        rules.add_path(os.path.join(self.sandbox.root, "rules", "prom"))
+        rules_file_dict = rules.as_dict()
         self.assertEqual({}, rules_file_dict)
 
     def test_non_recursive_lma_format_loading_from_root_dir(self):
-        rules_file_dict = (
-            AlertRules(self.topology)
-            .add_from_path(os.path.join(self.sandbox.root, "rules", "prom", "lma_format"))
-            .as_dict()
-        )
+        rules = AlertRules(self.topology)
+        rules.add_path(os.path.join(self.sandbox.root, "rules", "prom", "lma_format"))
+        rules_file_dict = rules.as_dict()
 
         expected_freestanding_rule = {
             "alert": "free_standing",
@@ -365,11 +361,9 @@ class TestAlertRulesWithOneRulePerFile(unittest.TestCase):
         self.assertEqual(expected_rules_file, rules_file_dict)
 
     def test_non_recursive_official_format_loading_from_root_dir(self):
-        rules_file_dict = (
-            AlertRules(self.topology)
-            .add_from_path(os.path.join(self.sandbox.root, "rules", "prom", "prom_format"))
-            .as_dict()
-        )
+        rules = AlertRules(self.topology)
+        rules.add_path(os.path.join(self.sandbox.root, "rules", "prom", "prom_format"))
+        rules_file_dict = rules.as_dict()
 
         expected_alert_rule = {
             "alert": "CPUOverUse",
@@ -395,14 +389,9 @@ class TestAlertRulesWithOneRulePerFile(unittest.TestCase):
           - For rules in lma format, core group name is the filename
           - For rules in official format, core group name is the group name in the file
         """
-        rules_file_dict = (
-            AlertRules(self.topology)
-            .add_from_path(
-                os.path.join(self.sandbox.root, "rules", "prom"),
-                recursive=True,
-            )
-            .as_dict()
-        )
+        rules = AlertRules(self.topology)
+        rules.add_path(os.path.join(self.sandbox.root, "rules", "prom"), recursive=True)
+        rules_file_dict = rules.as_dict()
 
         expected_alert_rule = {
             "alert": "CPUOverUse",
@@ -460,14 +449,9 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
         sandbox = Sandbox()
         sandbox.put_file("rules/file.rule", yaml.safe_dump(rules_file_dict))
 
-        rules_file_dict_read = (
-            AlertRules(self.topology)
-            .add_from_path(
-                os.path.join(sandbox.root, "rules"),
-                recursive=False,
-            )
-            .as_dict()
-        )
+        rules = AlertRules(self.topology)
+        rules.add_path(os.path.join(sandbox.root, "rules"), recursive=False)
+        rules_file_dict_read = rules.as_dict()
 
         expected_rules_file = {
             "groups": [
@@ -502,14 +486,9 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
         sandbox = Sandbox()
         sandbox.put_file("rules/file.rule", yaml.safe_dump(rules_file_dict))
 
-        rules_file_dict_read = (
-            AlertRules(self.topology)
-            .add_from_path(
-                os.path.join(sandbox.root, "rules"),
-                recursive=False,
-            )
-            .as_dict()
-        )
+        rules = AlertRules(self.topology)
+        rules.add_path(os.path.join(sandbox.root, "rules"), recursive=False)
+        rules_file_dict_read = rules.as_dict()
 
         expected_rules_file = {
             "groups": [
@@ -530,14 +509,9 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
         sandbox = Sandbox()
         sandbox.put_file("rules/file.rule", yaml.safe_dump(rules_file_dict))
 
-        rules_file_dict_read = (
-            AlertRules(self.topology)
-            .add_from_path(
-                os.path.join(sandbox.root, "rules"),
-                recursive=False,
-            )
-            .as_dict()
-        )
+        rules = AlertRules(self.topology)
+        rules.add_path(os.path.join(sandbox.root, "rules"), recursive=False)
+        rules_file_dict_read = rules.as_dict()
 
         expected_rules_file = {
             "groups": [
@@ -568,14 +542,9 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
             ("rules/a/b/file.rule", yaml.safe_dump(self.gen_rule(2))),
         )
 
-        rules_file_dict_read = (
-            AlertRules(self.topology)
-            .add_from_path(
-                os.path.join(sandbox.root, "rules"),
-                recursive=True,
-            )
-            .as_dict()
-        )
+        rules = AlertRules(self.topology)
+        rules.add_path(os.path.join(sandbox.root, "rules"), recursive=True)
+        rules_file_dict_read = rules.as_dict()
 
         expected_rules_file = {
             "groups": [

--- a/tests/unit/test_endpoint_provider.py
+++ b/tests/unit/test_endpoint_provider.py
@@ -23,7 +23,7 @@ from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.testing import Harness
 
-from .helpers import Sandbox
+from .helpers import TempFolderSandbox
 
 RELATION_NAME = "metrics-endpoint"
 PROVIDER_META = f"""
@@ -322,7 +322,7 @@ class TestAlertRulesWithOneRulePerFile(unittest.TestCase):
         }
         rules_file_dict = {"groups": [{"name": "group1", "rules": [alert_rule]}]}
 
-        self.sandbox = Sandbox()
+        self.sandbox = TempFolderSandbox()
         self.sandbox.put_files(
             ("rules/prom/mixed_format/lma_rule.rule", yaml.safe_dump(alert_rule)),
             ("rules/prom/mixed_format/standard_rule.rule", yaml.safe_dump(rules_file_dict)),
@@ -446,7 +446,7 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
     def test_load_multiple_rules_per_file(self):
         """Test official format with multiple alert rules per group in multiple groups."""
         rules_file_dict = {"groups": [self.gen_group(1), self.gen_group(2)]}
-        sandbox = Sandbox()
+        sandbox = TempFolderSandbox()
         sandbox.put_file("rules/file.rule", yaml.safe_dump(rules_file_dict))
 
         rules = AlertRules(self.topology)
@@ -483,7 +483,7 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
                 }
             ]
         }
-        sandbox = Sandbox()
+        sandbox = TempFolderSandbox()
         sandbox.put_file("rules/file.rule", yaml.safe_dump(rules_file_dict))
 
         rules = AlertRules(self.topology)
@@ -506,7 +506,7 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
 
     def test_duplicated_group_names_within_a_file_are_silently_accepted(self):
         rules_file_dict = {"groups": [self.gen_group("same"), self.gen_group("same")]}
-        sandbox = Sandbox()
+        sandbox = TempFolderSandbox()
         sandbox.put_file("rules/file.rule", yaml.safe_dump(rules_file_dict))
 
         rules = AlertRules(self.topology)
@@ -535,7 +535,7 @@ class TestAlertRulesWithMultipleRulesPerFile(unittest.TestCase):
         self.assertDictEqual(expected_rules_file, rules_file_dict_read)
 
     def test_deeply_nested(self):
-        sandbox = Sandbox()
+        sandbox = TempFolderSandbox()
         sandbox.put_files(
             ("rules/file.rule", yaml.safe_dump(self.gen_rule(0))),
             ("rules/a/file.rule", yaml.safe_dump(self.gen_rule(1))),

--- a/tox.ini
+++ b/tox.ini
@@ -69,6 +69,7 @@ deps =
     coverage[toml]
     responses
     -r{toxinidir}/requirements.txt
+    deepdiff
 commands =
     coverage run \
       --source={[vars]src_path},{[vars]lib_path} \
@@ -92,8 +93,8 @@ lma_bundle_dir = {envtmpdir}/lma-light-bundle
 deps =
     # deps from lma-bundle - these are needed here because will be running pytest on lma-bundle
     jinja2
-    #git+https://github.com/juju/python-libjuju.git
-    juju
+    git+https://github.com/juju/python-libjuju.git
+    #juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
 allowlist_externals =


### PR DESCRIPTION
This PR proposes the following changes to add support for official format (`groups:` etc.) in addition to lma-format (`alerts:...` level only):
- [x] `class AlertRules` is where aggregating all rules files takes place (optional: recursively).
- [x] in the case of lma-format alerts, the filename is used to generate the group name.