### PR TITLE
only run for push events on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,10 @@
 name: Run-Tests
 
-on: [pull_request, push]
+on: 
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 jobs:
   lint:


### PR DESCRIPTION
current configuration duplicates as prs will get counted twice (once for push, once for pr). this way, it will only run on pushes to main in addition to all pull requests