### PR TITLE
Use python-libjuju from github

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -69,8 +69,8 @@ commands =
 description = Run integration tests
 deps =
     aiohttp
-    #git+https://github.com/juju/python-libjuju.git
-    juju
+    git+https://github.com/juju/python-libjuju.git
+    #juju
     pytest
     git+https://github.com/charmed-kubernetes/pytest-operator.git
 commands =


### PR DESCRIPTION
This commit Python libjuju is used from github because of a
bug in Model.reset() method which has been fixed in github
but not in the current released version.