### PR TITLE
Fix incorrect charm name key in Juju topology object

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -531,7 +531,7 @@ class JujuTopology:
             "model": self.model,
             "model_uuid": self.model_uuid,
             "application": self.application,
-            "charm": self.charm_name,
+            "charm_name": self.charm_name,
         }
 
     def as_dict_with_promql_labels(self):


### PR DESCRIPTION
A previous commit introduced a bug in accessing the charm name
relation data key in the Juju Topology object.

This commit fixes the issue.