### PR TITLE
Remove mutable default job list

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1153,7 +1153,7 @@ class MetricsEndpointProvider(Object):
         self,
         charm,
         relation_name: str = DEFAULT_RELATION_NAME,
-        jobs=[],
+        jobs=None,
         alert_rules_path: str = DEFAULT_ALERT_RULES_RELATIVE_PATH,
     ):
         """Construct a metrics provider for a Prometheus charm.
@@ -1279,6 +1279,7 @@ class MetricsEndpointProvider(Object):
         self._alert_rules_path = alert_rules_path
         self._relation_name = relation_name
         # sanitize job configurations to the supported subset of parameters
+        jobs = [] if jobs is None else jobs
         self._jobs = [_sanitize_scrape_configuration(job) for job in jobs]
 
         events = self._charm.on[self._relation_name]


### PR DESCRIPTION
This commit replaces the mutable default argument by a sentinel.
Mutable defaults are potential bugs. Though this bug does not
manifest in the charm constructor since it is invoked only once
in each process, the commit never the less removes it as a good
practice.

Closes: #113